### PR TITLE
Added citations and patents filter with checkboxes

### DIFF
--- a/index.html
+++ b/index.html
@@ -170,6 +170,16 @@
               oninput="filterPapers()"
             />
           </div>
+          <div class="filter-container">
+            <label style="font-size: 0.95em;">
+              <input type="checkbox" id="includeCitations" onchange="filterPapers()" />
+              Include Citations
+            </label>
+            <label style="font-size: 0.95em; margin-left:8px;">
+              <input type="checkbox" id="includePatents" onchange="filterPapers()" />
+              Include Patents
+            </label>
+            </div>
         </div>
       </div>
 

--- a/script.js
+++ b/script.js
@@ -108,6 +108,8 @@ function filterPapers() {
   const authorFilter = document
     .getElementById("authorFilter")
     .value.toLowerCase();
+  const includeCitations = document.getElementById("includeCitations").checked;
+  const includePatents = document.getElementById("includePatents").checked;
 
   // Filter papers based on search, topic, year, and author
   currentFilteredPapers = papers.filter((paper) => {
@@ -122,6 +124,9 @@ function filterPapers() {
       (!maxYear || paper.year <= maxYear);
     const matchesAuthor =
       authorFilter === "" || paper.authors.toLowerCase().includes(authorFilter);
+    //Checkboxes logic
+    if (includeCitations && !paper.isCitation) return false;
+    if (includePatents && !paper.isPatent) return false;
 
     return matchesSearch && matchesTopic && matchesYear && matchesAuthor;
   });


### PR DESCRIPTION
✨ Feature: Added 'Include Citations' and 'Include Patents' filters with checkboxes.

🧾Description:
This PR introduces two new checkbox filters in the filters row:
Include Citations → Allows filtering results to only include items with citations.
Include Patents → Allows filtering results to only include items with patents.

⚙️Changes Made:
index.html → Added two new checkboxes in the filters row with inline styling
script.js → Integrated checkbox logic with existing filter functionality.

✅Testing:
Checked that the checkboxes display correctly in the filter row.
Verified they trigger filtering logic when toggled.
Ensured no existing functionality is broken.

Issue Reference:
Closes #<98>
<img width="959" height="406" alt="ss2" src="https://github.com/user-attachments/assets/8129018c-9ee4-4af3-aa0a-4e50ef28d379" />
