### PR TITLE
Add Glossary Page for Research Terminology

### DIFF
--- a/glossary.css
+++ b/glossary.css
@@ -1,0 +1,136 @@
+/* Base Styles */
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+body {
+  font-family: 'Segoe UI', sans-serif;
+  background-color: #f9f9f9;
+  color: #333;
+}
+
+/* Header */
+.glossary-header {
+  text-align: center;
+  padding: 2rem 1rem;
+  background: linear-gradient(135deg, #4a90e2, #357abd);
+  color: white;
+}
+.glossary-header h1 {
+  font-size: 2.5rem;
+}
+.glossary-header p {
+  margin: 0.5rem 0 1rem;
+}
+.glossary-header input {
+  padding: 10px;
+  width: 90%;
+  max-width: 400px;
+  border: none;
+  border-radius: 5px;
+  font-size: 1rem;
+}
+.glossary-header input:focus {
+  outline: none;
+  box-shadow: 0 0 5px rgba(74, 144, 226, 0.5);
+}
+
+
+/* Alphabet Navigation */
+.alphabet-nav {
+  text-align: center;
+  padding: 1rem;
+  background: #eef3f9;
+}
+.alphabet-nav a {
+  margin: 0 0.3rem;
+  text-decoration: none;
+  color: #357abd;
+  font-weight: bold;
+  transition: color 0.3s ease;
+}
+.alphabet-nav a:hover {
+  color: #1e5a9e;
+  text-decoration: underline;
+}
+
+
+/* Glossary Items */
+.glossary-container {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 1.5rem;
+  padding: 2rem;
+}
+.glossary-item {
+  background: white;
+  border-radius: 8px;
+  padding: 1.5rem;
+  box-shadow: 0 4px 15px rgba(0,0,0,0.05);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+.glossary-item:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 8px 25px rgba(0,0,0,0.1);
+}
+.glossary-item h2 {
+  color: #357abd;
+  margin-bottom: 0.5rem;
+}
+.glossary-item p {
+  font-size: 0.95rem;
+  margin-bottom: 0.5rem;
+}
+.glossary-item small {
+  display: block;
+  font-size: 0.85rem;
+  color: #666;
+}
+.glossary-item a {
+  color: #4a90e2;
+  text-decoration: none;
+}
+.glossary-item a:hover {
+  text-decoration: underline;
+}
+/* Search Functionality */
+.glossary-header input[type="text"] {
+  width: 80%;
+  max-width: 500px;
+}
+
+
+/* Search Results */
+.glossary-item {
+  display: none;
+}
+.glossary-item.visible {
+  display: block;
+}
+
+/* Footer */
+.glossary-footer {
+  text-align: center;
+  padding: 1rem;
+  background: #357abd;
+  color: white;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .glossary-header h1 {
+    font-size: 2rem;
+  }
+}
+@media (max-width: 480px) {
+  .glossary-header input {
+    width: 100%;
+  }
+  .glossary-item {
+    padding: 1rem;
+  }
+  .glossary-item h2 {
+    font-size: 1.2rem;
+  }
+}

--- a/glossary.html
+++ b/glossary.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Glossary | Research Paper Organizer</title>
+  <link rel="stylesheet" href="glossary.css" />
+</head>
+<body>
+
+  <!-- Header -->
+  <header class="glossary-header">
+    <h1>📖 Research Glossary</h1>
+    <p>Understand research terms with clear definitions and examples</p>
+    <input type="text" id="searchBar" placeholder="Search for a term...">
+  </header>
+
+  <!-- Alphabet Navigation -->
+  <nav class="alphabet-nav">
+    <a href="#A">A</a>
+    <a href="#B">B</a>
+    <a href="#C">C</a>
+    <a href="#P">P</a>
+    <a href="#R">R</a>
+    <a href="#T">T</a>
+    <!-- Add more as needed -->
+  </nav>
+
+  <!-- Glossary List -->
+  <main class="glossary-container" id="glossaryList">
+
+    <div class="glossary-item" id="A">
+      <h2>Abstract</h2>
+      <p>A brief summary of a research paper or article, highlighting the key points and findings.</p>
+      <small><strong>Example:</strong> The abstract at the start of a scientific paper summarizes the objectives, methods, and results.</small>
+    </div>
+
+    <div class="glossary-item" id="B">
+      <h2>Bibliography</h2>
+      <p>A list of the books, articles, and other sources cited or consulted in a research work.</p>
+      <small><strong>Example:</strong> The bibliography section contains all the references used in the paper.</small>
+    </div>
+
+    <div class="glossary-item" id="C">
+      <h2>Citation</h2>
+      <p>A reference to a published or unpublished source, used to give credit to the original author.</p>
+      <small><strong>Example:</strong> According to Smith (2020), AI tools are changing research workflows.</small>
+    </div>
+
+    <div class="glossary-item" id="P">
+      <h2>Peer Review</h2>
+      <p>The evaluation of scholarly work by experts in the same field to ensure quality and validity. See also: <a href="#I">Impact Factor</a></p>
+      <small><strong>Example:</strong> The paper was accepted after two rounds of peer review.</small>
+    </div>
+
+    <div class="glossary-item" id="R">
+      <h2>Research Proposal</h2>
+      <p>A detailed plan outlining the objectives, methodology, and significance of a research project.</p>
+      <small><strong>Example:</strong> A proposal must be approved before starting a funded research project.</small>
+    </div>
+
+    <div class="glossary-item" id="T">
+      <h2>Thesis Statement</h2>
+      <p>A single sentence that summarizes the main point or claim of a research paper.</p>
+      <small><strong>Example:</strong> The thesis statement guides the entire structure of the paper.</small>
+    </div>
+
+  </main>
+
+  <!-- Footer -->
+  <footer class="glossary-footer">
+    <p>© 2025 Research Paper Organizer | Open Source Project</p>
+  </footer>
+
+  <script src="glossary.js"></script>
+</body>
+</html>

--- a/glossary.js
+++ b/glossary.js
@@ -1,0 +1,72 @@
+const glossaryTerms = [
+  { term: "Abstract", definition: "A summary of the research paper.", example: "The abstract outlined the study's objectives and results." },
+  { term: "Peer Review", definition: "The evaluation of academic work by others in the same field.", example: "The paper underwent peer review before publication." },
+  { term: "Citation", definition: "A reference to a published or unpublished source.", example: "The paper included citations to relevant literature." },
+  { term: "DOI", definition: "Digital Object Identifier, a unique alphanumeric string for a document.", example: "The DOI ensured readers could locate the article online." },
+  { term: "Hypothesis", definition: "A proposed explanation for a phenomenon.", example: "The hypothesis was tested through multiple experiments." },
+  { term: "Literature Review", definition: "A survey of scholarly sources relevant to a topic.", example: "The literature review provided context for the study." },
+  { term: "Plagiarism", definition: "Using someone else's work without proper attribution.", example: "The author avoided plagiarism by citing all sources." },
+  { term: "Impact Factor", definition: "A measure of a journal's influence.", example: "The journal had an impact factor of 5.2." },
+  { term: "Open Access", definition: "Research available without subscription fees.", example: "The paper was published in an open-access journal." },
+  { term: "Research Methodology", definition: "The strategy and process used to conduct research.", example: "The research methodology included surveys and interviews." }
+];
+
+// Select glossary container
+const glossaryContainer = document.querySelector(".glossary-container");
+
+// Render glossary terms
+glossaryTerms.forEach(item => {
+  const card = document.createElement("div");
+  card.classList.add("glossary-card");
+  card.innerHTML = `
+    <h3>${item.term}</h3>
+    <p>${item.definition}</p>
+    <small><strong>Example:</strong> ${item.example}</small>
+  `;
+  glossaryContainer.appendChild(card);
+});
+// Search functionality
+const searchInput = document.querySelector(".glossary-header input");
+searchInput.addEventListener("input", function() {
+    const searchTerm = searchInput.value.toLowerCase();
+    const glossaryItems = document.querySelectorAll(".glossary-item");
+    glossaryItems.forEach(item => {
+        const term = item.querySelector("h2").textContent.toLowerCase();
+        if (term.includes(searchTerm)) {
+            item.classList.add("visible");
+        } else {
+            item.classList.remove("visible");
+        }
+    });
+});
+// Alphabet navigation
+const alphabetLinks = document.querySelectorAll(".alphabet-nav a");
+alphabetLinks.forEach(link => {
+    link.addEventListener("click", function(e) {
+        e.preventDefault();
+        const targetId = this.getAttribute("href").substring(1);
+        const targetItem = document.getElementById(targetId);
+        if (targetItem) {
+            targetItem.scrollIntoView({ behavior: "smooth" });
+        }
+    });
+});
+
+// Highlight current section in alphabet navigation
+
+window.addEventListener("scroll", function() {
+    const scrollPosition = window.scrollY;
+    alphabetLinks.forEach(link => {
+        const targetId = link.getAttribute("href").substring(1);
+        const targetItem = document.getElementById(targetId);
+        if (targetItem) {
+            const itemPosition = targetItem.offsetTop;
+            const itemHeight = targetItem.offsetHeight;
+            if (scrollPosition >= itemPosition && scrollPosition < itemPosition + itemHeight) {
+                link.classList.add("active");
+            } else {
+                link.classList.remove("active");
+            }
+        }
+    });
+});


### PR DESCRIPTION
Issue: #68 


Description:

Currently, the Research Paper Organizer does not include a resource for explaining research-related terminology. Adding a Glossary page will provide clear definitions and examples for common academic and research terms, helping users—especially beginners—better understand the language of research.

Proposed Features:

Alphabetical List: Terms arranged from A–Z for easy browsing.
Search Bar: Quickly find a specific term.
Definitions with Examples: Each entry includes a short definition and a relevant example (e.g., how an abstract looks in a paper).
Clickable Cross-References: Link related terms (e.g., peer review → impact factor).
Optional Tooltips: Highlight glossary terms throughout the site with hover-over definitions.

Why This Will Work:

Makes the Tool More Inclusive: Helps beginners or non-native English speakers understand research terms without leaving the platform.
Improves User Confidence: Users can learn and apply terms correctly in their own research.
Enhances Educational Value: Turns the site into a learning resource, not just an organizer.
Encourages Return Visits: Users may revisit the glossary as a quick reference tool.