### PR TITLE
Adding a loader animation before it shows the main page

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,13 @@
     <link rel="manifest" href="/site.webmanifest">
 </head>
 <body>
+    <!-- Loading Screen -->
+    <div id="loading-screen">
+      <div class="loader">
+        <i class="fa-solid fa-spinner"></i>
+        <h2 id="loading-text">Organizing your thoughts<span class="dots"></span></h2>
+      </div>
+    </div>
     <!-- Navigation -->
     <nav class="landing-nav">
         <div class="nav-container">
@@ -262,5 +269,31 @@
     </footer>
 
     <script src="landing.js"></script>
+    <script>
+      document.addEventListener("DOMContentLoaded", function () {
+        const loadingScreen = document.getElementById("loading-screen");
+        const loadingText = document.getElementById("loading-text");
+
+        const texts = ["Organizing your thoughts...", "Drafting your ideas..."];
+
+        let index = 0;
+
+        // Change text every 4 seconds
+        const textInterval = setInterval(() => {
+          index = (index + 1) % texts.length;
+          loadingText.style.opacity = 0; // fade out
+          setTimeout(() => {
+            loadingText.innerHTML = texts[index] + '<span class="dots"></span>';
+            loadingText.style.opacity = 1; // fade in
+          }, 500);
+        }, 3000);
+
+        // Hide loading screen after 6 seconds
+        setTimeout(() => {
+          clearInterval(textInterval); // stop changing text
+          loadingScreen.classList.add("hidden");
+        }, 6000); // adjust as needed
+      });
+    </script>
 </body>
 </html>

--- a/landing.css
+++ b/landing.css
@@ -505,3 +505,78 @@ body {
         text-align: center; /* Center text for better readability */
     }
 }
+/*Loading page*/
+#loading-screen {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100vh;
+    background: white;
+    color: rgb(34, 51, 232);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 9999;
+    transition: opacity 0.5s ease, visibility 0.5s ease;
+}
+
+#loading-text {
+  transition: opacity 0.5s ease-in-out;
+}
+
+#loading-screen.hidden {
+    opacity: 0;
+    visibility: hidden;
+}
+
+.loader {
+    text-align: center;
+}
+
+.loader i {
+    font-size: 4.5rem;
+    animation: spin 2s linear infinite;
+}
+
+.loader h2 {
+    margin-top: 1.5rem;
+    font-size: 2.1rem;
+}
+
+.dots::after {
+    content: "";
+    display: inline-block;
+    animation: dots 1.5s steps(5, end) infinite;
+}
+
+@keyframes dots {
+    0% {
+        content: "";
+    }
+    20% {
+        content: ".";
+    }
+    40% {
+        content: "..";
+    }
+    60% {
+        content: "...";
+    }
+    80%{
+        content: "....";
+    }
+    100% {
+        content: "";
+    }
+}
+
+/* Spin Animation */
+@keyframes spin {
+    from {
+        transform: rotate(0deg);
+    }
+    to {
+        transform: rotate(360deg);
+    }
+}


### PR DESCRIPTION
This PR introduces a loader page that appears for 6–7 seconds before the main page loads. The purpose of this loader is to improve the user's experience by providing visual feedback during content loading.

Key Features:

1.Loader displays for ~6–7 seconds
2.Smooth animation to indicate progress
3.Automatically redirects to the main content after the loading completes

<img width="1888" height="962" alt="Screenshot 2025-08-17 113748" src="https://github.com/user-attachments/assets/aa884703-040f-4875-b7c3-8178778f2a3c" />
