### PR TITLE
Fixed Missing Research and Tools Cards on Tools Page

### DIFF
--- a/tools.html
+++ b/tools.html
@@ -44,6 +44,13 @@
 
 <!-- Tools Grid -->
 <div class="tools-container" id="toolsList">
+  <div class="tool-card" data-category="analysis">
+    <img src="https://cdn-icons-png.flaticon.com/512/337/337946.png" alt="PDF Annotator">
+    <h3>PDF Annotator</h3>
+    <p>Highlight, annotate, and add notes to PDF research papers directly in your browser.</p>
+    <a href="pdf-viewer.html">Open Tool</a>
+  </div>
+  
   <div class="tool-card" data-category="citation">
     <img src="https://cdn-icons-png.flaticon.com/512/1828/1828911.png" alt="Citation Generator">
     <h3>Citation Machine</h3>
@@ -86,12 +93,6 @@
     <a href="https://www.duplichecker.com/" target="_blank">Visit</a>
   </div>
 
-  <div class="tool-card" data-category="analysis">
-    <img src="https://cdn-icons-png.flaticon.com/512/337/337946.png" alt="PDF Annotator">
-    <h3>PDF Annotator</h3>
-    <p>Highlight, annotate, and add notes to PDF research papers directly in your browser.</p>
-    <a href="pdf-viewer.html">Open Tool</a>
-  </div>
 </div>
 
     <!-- Back to Top Button -->


### PR DESCRIPTION
This PR fixes the issue where the Research and Tools cards were missing on the Tools Page.
Now, the page correctly displays all intended cards, ensuring better visibility of resources and improved user navigation.

fixed #222 