### PR TITLE
Fix: linkedin icon redirects correctly in home page

### DIFF
--- a/home.html
+++ b/home.html
@@ -624,7 +624,7 @@ box-shadow: rgba(0,0,0,0.8);
             <i class="fab fa-twitter" aria-hidden="true"></i>
             <span class="sr-only">Twitter</span>
           </a>
-          <a href="#" target="_blank" title="LinkedIn" rel="noopener">
+          <a href="https://www.linkedin.com/in/supriyapandey595" target="_blank" title="LinkedIn" rel="noopener">
             <i class="fab fa-linkedin" aria-hidden="true"></i>
             <span class="sr-only">LinkedIn</span>
           </a>


### PR DESCRIPTION
this pr addresses issue #332 

## PR Description:
This PR fixes the LinkedIn icon in the footer’s Connect section on the Home page:

Ensures the LinkedIn icon redirects to the correct project LinkedIn profile/page.

Opens the link in a new tab to preserve the user’s current session.
