### PR TITLE
Mobile-Responsive Chatbase Chatbot:

### DIFF
--- a/home.html
+++ b/home.html
@@ -1095,9 +1095,66 @@ backToTop.addEventListener("click", () => {
   </script>
 
     <script src="js/script.js"></script>
+<style>
+/* Bubble button mobile sizing */
+@media (max-width: 768px) {
+  button#chatbase-bubble-button {
+    position: fixed !important;
+    /* bottom: 300px !important;
+    left:300px !important; */
+    width: 55px !important;
+    height: 55px !important;
+    border-radius: 50% !important;
+    z-index: 2147483647 !important; 
+  }
 
+  button#chatbase-bubble-button svg {
+    width: 28px !important;
+    height: 28px !important;
+  }
+}
+@media (max-width: 768px) {
+  #chatbase-bubble-button {
+    position: fixed !important;
+    z-index: 2147483647 !important; 
+  }
+
+  /* Jab window open ho */
+  #chatbase-bubble-window[style*="display: flex"] + #chatbase-bubble-button {
+    bottom: 15px !important; 
+  }
+}
+button#chatbase-bubble-button div {
+  width: 100% !important;
+  height: 100% !important;
+  display: flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+}
+
+/* Window responsive – act like card */
+@media (max-width: 768px) {
+  #chatbase-bubble-window {
+    position: absolute;
+    width: 90% !important;
+    height: 75% !important;
+    bottom: 80px !important;
+    right: 15px !important;
+    left: auto !important;
+    top: auto !important;
+    border-radius: 16px !important;
+    background: transparent !important; /* remove white bg */
+    box-shadow: 0 4px 12px rgba(0,0,0,0.3) !important;
+  }
+
+  #chatbase-bubble-window iframe {
+    border-radius: 16px !important;
+    background: black !important; /* chatbot stays black */
+  }
+}
+</style>
     <!-- Chatbase Integration -->
-    <script>
+     <script>
         (function(){
             if(!window.chatbase || window.chatbase("getState") !== "initialized"){
                 window.chatbase = (...arguments) => {
@@ -1122,7 +1179,59 @@ backToTop.addEventListener("click", () => {
             else { window.addEventListener("load", onLoad) }
         })();
     </script>
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const bubbleWindow = document.getElementById("chatbase-bubble-window");
+  const bubbleButton = document.getElementById("chatbase-bubble-button");
 
+  if (!bubbleWindow || !bubbleButton) return;
+
+  function setImportant(el, prop, value) {
+    el.style.setProperty(prop, value, "important");
+  }
+
+  function updateButtonPosition() {
+    const rect = bubbleWindow.getBoundingClientRect();
+
+    if (bubbleWindow.style.display === "flex") {
+      // Button below chat window (no changes here)
+      const topPos = window.scrollY + rect.bottom + 10;
+      const leftPos = rect.left;
+
+      setImportant(bubbleButton, "position", "fixed");
+      setImportant(bubbleButton, "top", topPos + "px");
+      setImportant(bubbleButton, "left", leftPos + "px");
+      setImportant(bubbleButton, "bottom", "auto");
+      setImportant(bubbleButton, "right", "auto");
+    } else {
+      // Closed position with left:300px; bottom:300px
+      setImportant(bubbleButton, "position", "fixed");
+      setImportant(bubbleButton, "bottom", "300px");
+      setImportant(bubbleButton, "left", "300px");
+      setImportant(bubbleButton, "top", "auto");
+      setImportant(bubbleButton, "right", "auto");
+    }
+  }
+
+  updateButtonPosition();
+  window.addEventListener("scroll", updateButtonPosition);
+  window.addEventListener("resize", updateButtonPosition);
+
+  // Toggle chat window
+  bubbleButton.addEventListener("click", () => {
+    bubbleWindow.style.display = bubbleWindow.style.display === "flex" ? "none" : "flex";
+    updateButtonPosition();
+  });
+
+  // Handle iframe close button
+  window.addEventListener("message", (event) => {
+    if (event.data?.type === "chatbase-close") {
+      bubbleWindow.style.display = "none";
+      updateButtonPosition();
+    }
+  });
+});
+</script>
 </body>
 
 </html>


### PR DESCRIPTION
## 🚀 Pull Request

### this pr addresses issue #334 

###  Description

## What I did:

- Added the Chatbase chatbot with a working toggle button for mobile.

- The toggle button can open and close the chat window as expected.

- Button automatically positions itself below the chat window when open.

- Adjusted the chat window size so it’s not fullscreen on mobile

- Fixed most responsiveness issues with the chat window placement.


## Notes / Challenges:

- The chatbot is inside an iframe, so getting the right classes and IDs for styling and JS was tricky.

- Because the navbar and top sections aren’t fully responsive yet, the initial viewport is wider than expected. This makes the toggle button appear slightly outside the screen initially.

- Once the top section and navbar are responsive, the chatbot will automatically align perfectly

---

### 📸 Screenshots
## before :
<img width="301" height="391" alt="Screenshot 2025-08-30 000149" src="https://github.com/user-attachments/assets/7f4cf3e6-bc70-403e-9ecf-707e58c4007f" />

<img width="242" height="391" alt="Screenshot 2025-08-30 000236" src="https://github.com/user-attachments/assets/8e39ccc6-d455-4b05-bcec-f4b767cf72b6" />

## after:

<img width="260" height="387" alt="Screenshot 2025-08-30 000202" src="https://github.com/user-attachments/assets/0be6d5a6-ccb5-420e-b5cb-c91b0f8697c8" />

<img width="262" height="393" alt="Screenshot 2025-08-30 000217" src="https://github.com/user-attachments/assets/ae707c1d-3936-4619-b01f-023dfdb60a50" />

---

### 🙌 Additional Notes
<!-- Add anything else you’d like to mention (e.g., learning from this PR, challenges faced). -->
