### PR TITLE
Feature:Dark mode in Open Source, Masthead, and Glossary Pages

### DIFF
--- a/Masthead.html
+++ b/Masthead.html
@@ -1,370 +1,556 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Masthead | Research Paper Organizer</title>
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Masthead | Research Paper Organizer</title>
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"
+    />
 
-  <style>
-    /* ===== Root Variables ===== */
-    :root {
-      --primary: #357abd;
-      --secondary: #4a90e2;
-      --gradient: linear-gradient(135deg, #4a90e2, #357abd);
-      --dark: #111827;
-      --light: #f9fafb;
-      --text-light: #6b7280;
-      --white: #ffffff;
-      --shadow: 0 10px 25px rgba(0, 0, 0, 0.1);
-    }
+    <style>
+      /* ===== Root Variables ===== */
+      :root {
+        --primary: #357abd;
+        --secondary: #4a90e2;
+        --gradient: linear-gradient(135deg, #4a90e2, #357abd);
+        --dark: #111827;
+        --light: #f9fafb;
+        --text-light: #6b7280;
+        --white: #ffffff;
+        --shadow: 0 10px 25px rgba(0, 0, 0, 0.1);
+      }
 
-    * { margin: 0; padding: 0; box-sizing: border-box; }
-    body {
-      font-family: "Inter", sans-serif;
-      background: var(--light);
-      color: var(--dark);
-      line-height: 1.6;
-    }
+      body.dark-mode {
+        --primary: #60a5fa;
+        --secondary: #3b82f6;
+        --gradient: linear-gradient(135deg, #1e3a8a, #1e40af);
+        --dark: #f9fafb;
+        --light: #111827;
+        --text-light: #9ca3af;
+        --white: #1f2937;
+        --shadow: 0 10px 25px rgba(255, 255, 255, 0.05);
+        background: var(--light);
+        color: var(--dark);
+      }
 
-    a { text-decoration: none; color: inherit; transition: 0.3s; }
+      .dark-toggle {
+        font-size: 1.3rem;
+        cursor: pointer;
+        color: var(--primary);
+        margin-left: 1rem;
+        transition: transform 0.3s ease;
+      }
+      .dark-toggle:hover {
+        transform: rotate(20deg);
+      }
 
-    /* ===== Navbar ===== */
-    .landing-nav {
-      position: fixed;
-      top: 0;
-      width: 100%;
-      background: rgba(255, 255, 255, 0.9);
-      backdrop-filter: blur(12px);
-      border-bottom: 1px solid #e5e7eb;
-      z-index: 1000;
-    }
-    .nav-container {
-      max-width: 1200px;
-      margin: auto;
-      padding: 1rem 20px;
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-    }
-    .nav-brand {
-      font-size: 1.4rem;
-      font-weight: 700;
-      display: flex;
-      align-items: center;
-      color: var(--primary);
-    }
-    .nav-brand i { margin-right: 8px; }
-
-    .nav-links {
-      display: flex;
-      gap: 1.5rem;
-      align-items: center;
-    }
-    .nav-links a {
-      font-weight: 500;
-      color: var(--dark);
-      position: relative;
-    }
-    .nav-links a::after {
-      content: "";
-      position: absolute;
-      left: 0; bottom: -4px;
-      width: 0; height: 2px;
-      background: var(--primary);
-      transition: width 0.3s;
-    }
-    .nav-links a:hover::after { width: 100%; }
-
-    .btn-primary {
-      background: var(--gradient);
-      color: white;
-      padding: 0.6rem 1.2rem;
-      border-radius: 8px;
-      border: none;
-      font-weight: 600;
-      cursor: pointer;
-      box-shadow: var(--shadow);
-    }
-
-    /* ===== Hero ===== */
-    .masthead-hero {
-      padding: 120px 20px 80px;
-      text-align: center;
-      background: var(--gradient);
-      color: white;
-      border-radius: 0 0 50px 50px;
-    }
-    .masthead-hero h1 {
-      font-size: 2.5rem;
-      font-weight: 800;
-      margin-bottom: 15px;
-    }
-    .masthead-hero p {
-      max-width: 700px;
-      margin: auto;
-      font-size: 1.2rem;
-      opacity: 0.9;
-    }
-
-    /* ===== Sections ===== */
-    .section {
-      max-width: 1100px;
-      margin: 80px auto;
-      padding: 0 20px;
-    }
-    .section h2 {
-      text-align: center;
-      font-size: 2rem;
-      margin-bottom: 40px;
-    }
-    .section h2::after {
-      content: "";
-      width: 60px; height: 4px;
-      background: var(--primary);
-      display: block;
-      margin: 10px auto;
-      border-radius: 4px;
-    }
-
-    /* ===== Team Grid ===== */
-    .team-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-      gap: 30px;
-    }
-    .team-card {
-      background: var(--white);
-      border-radius: 16px;
-      padding: 20px;
-      text-align: center;
-      box-shadow: var(--shadow);
-      transition: all 0.3s;
-      opacity: 0;
-      transform: translateY(20px);
-    }
-    .team-card.show { opacity: 1; transform: translateY(0); }
-    .team-card img {
-      width: 120px; height: 120px;
-      border-radius: 50%;
-      object-fit: cover;
-      margin-bottom: 12px;
-      border: 4px solid #e0e7ff;
-    }
-    .team-card h3 { font-size: 1.2rem; margin-bottom: 5px; }
-    .team-card p.role { font-size: 0.9rem; color: var(--text-light); margin-bottom: 8px; }
-
-    /* ===== Contact ===== */
-    .contact {
-      text-align: center;
-      padding: 30px;
-      background: #eef6ff;
-      border-radius: 16px;
-    }
-    .contact a {
-      margin: 0 8px;
-      font-size: 1.5rem;
-      color: var(--primary);
-    }
-
-    /* ===== Footer ===== */
-   .modern-footer {
-  background: linear-gradient(135deg, #1f3c88, #2c5aa0);
-  color: #fff;
-  padding: 60px 20px 20px;
-  border-radius: 25px 25px 0 0;
+      /* Navbar Dark Mode */
+body.dark-mode .landing-nav {
+  background: rgba(31, 41, 55, 0.95); /* dark background with blur */
+  border-bottom: 1px solid #374151;
 }
-.footer-top {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 30px;
-  margin-bottom: 30px;
+
+body.dark-mode .nav-brand {
+  color: var(--primary);
 }
-.footer-card h3, .footer-card h4 {
-  margin-bottom: 15px;
+
+body.dark-mode .nav-links a {
+  color: var(--dark); /* light text */
 }
-.footer-links-section ul {
-  list-style: none;
+
+body.dark-mode .nav-links a::after {
+  background: var(--primary);
 }
-.footer-links-section ul li {
-  margin: 10px 0;
+
+body.dark-mode .contact {
+  background: #1f2937; /* dark gray background */
+  color: var(--dark);  /* light text */
 }
-.footer-links-section ul li a {
-  text-decoration: none;
-  color: #ddd;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  transition: all 0.3s ease;
+
+body.dark-mode .contact a {
+  color: var(--primary);
 }
-.footer-links-section ul li a:hover {
-  color: #fff;
-  transform: translateX(5px);
+
+body.dark-mode .contact p {
+  color: var(--dark);
 }
-.social-icons a {
-  font-size: 1.4rem;
-  margin-right: 15px;
-  color: #ddd;
-  background: rgba(255,255,255,0.1);
-  padding: 10px;
-  border-radius: 50%;
-  transition: all 0.3s ease;
-}
-.social-icons a:hover {
-  color: #2c5aa0;
-  background: white;
-  transform: scale(1.2);
-}
-.footer-bottom {
-  text-align: center;
-  font-size: 0.9rem;
-  border-top: 1px solid rgba(255,255,255,0.2);
-  padding-top: 15px;
-}
-.heart {
-  color: red;
-}
-    /* Back to Top */
-    #backToTop {
-      position: fixed; bottom: 30px; right: 20px;
-      width: 50px; height: 50px;
-      border-radius: 50%;
-      background: var(--gradient);
-      color: #fff; border: none;
-      font-size: 20px;
-      display: none;
-      cursor: pointer;
-      box-shadow: var(--shadow);
-    }
 
-    /* Responsive */
-    @media (max-width: 768px) {
-      .nav-links { display: none; }
-      .mobile-menu-toggle { display: block; font-size: 1.5rem; cursor: pointer; }
-    }
-  </style>
-</head>
-<body>
 
-  <!-- Navbar -->
-  <nav class="landing-nav">
-    <div class="nav-container">
-      <div class="nav-brand"><i class="fas fa-book-open"></i> Research Paper Organizer</div>
-      <div class="nav-links">
-        <a href="index.html">Home</a>
-        <a href="about.html">About</a>
-        <a href="tools.html">Tools</a>
-        <a href="contact.html">Contact</a>
-        <button class="btn-primary" onclick="location.href='signup.html'">Get Started</button>
-      </div>
-      <div class="mobile-menu-toggle"><i class="fas fa-bars"></i></div>
-    </div>
-  </nav>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        font-family: "Inter", sans-serif;
+        background: var(--light);
+        color: var(--dark);
+        line-height: 1.6;
+      }
 
-  <!-- Hero -->
-  <section class="masthead-hero">
-    <h1>Meet the Minds Behind Research Paper Organizer</h1>
-    <p>Our team of researchers, developers, and advisors is dedicated to building smarter academic tools.</p>
-  </section>
+      a {
+        text-decoration: none;
+        color: inherit;
+        transition: 0.3s;
+      }
 
-  <!-- Core Team -->
-  <section class="section">
-    <h2>Core Team</h2>
-    <div class="team-grid">
-      <div class="team-card"><img src="https://randomuser.me/api/portraits/women/44.jpg
-"><h3>Dr. Sarah Lee</h3><p class="role">Lead Researcher</p><p>AI & NLP specialist with 10+ years of experience.</p></div>
-      <div class="team-card"><img src="https://randomuser.me/api/portraits/men/32.jpg
-"><h3>Michael Chen</h3><p class="role">Full-Stack Developer</p><p>Passionate about scalable, user-friendly tools.</p></div>
-      <div class="team-card"><img src="https://randomuser.me/api/portraits/women/12.jpg
+      /* ===== Navbar ===== */
+      .landing-nav {
+        position: fixed;
+        top: 0;
+        width: 100%;
+        background: rgba(255, 255, 255, 0.9);
+        backdrop-filter: blur(12px);
+        border-bottom: 1px solid #e5e7eb;
+        z-index: 1000;
+      }
+      .nav-container {
+        max-width: 1200px;
+        margin: auto;
+        padding: 1rem 20px;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+      }
+      .nav-brand {
+        font-size: 1.4rem;
+        font-weight: 700;
+        display: flex;
+        align-items: center;
+        color: var(--primary);
+      }
+      .nav-brand i {
+        margin-right: 8px;
+      }
 
-"><h3>Ananya Sharma</h3><p class="role">Product Designer</p><p>Creates intuitive, accessible academic tools.</p></div>
-    </div>
-  </section>
+      .nav-links {
+        display: flex;
+        gap: 1.5rem;
+        align-items: center;
+      }
+      .nav-links a {
+        font-weight: 500;
+        color: var(--dark);
+        position: relative;
+      }
+      .nav-links a::after {
+        content: "";
+        position: absolute;
+        left: 0;
+        bottom: -4px;
+        width: 0;
+        height: 2px;
+        background: var(--primary);
+        transition: width 0.3s;
+      }
+      .nav-links a:hover::after {
+        width: 100%;
+      }
 
-  <!-- Advisors -->
-  <section class="section">
-    <h2>Advisors</h2>
-    <div class="team-grid">
-      <div class="team-card"><img src="https://randomuser.me/api/portraits/men/82.jpg
-"><h3>Prof. James Brown</h3><p class="role">Advisor</p><p>Expert in digital libraries & open-source research.</p></div>
-    </div>
-  </section>
+      .btn-primary {
+        background: var(--gradient);
+        color: white;
+        padding: 0.6rem 1.2rem;
+        border-radius: 8px;
+        border: none;
+        font-weight: 600;
+        cursor: pointer;
+        box-shadow: var(--shadow);
+      }
 
-  <!-- Contact -->
-  <section class="section">
-    <h2>Contact & Info</h2>
-    <div class="contact">
-      <p>We’d love to hear from you. Reach out anytime!</p>
-      <a href="mailto:team@researchorganizer.com"><i class="fas fa-envelope"></i></a>
-      <a href="#"><i class="fab fa-github"></i></a>
-      <a href="#"><i class="fab fa-linkedin"></i></a>
-      <p style="margin-top: 10px; color: var(--text-light);">Version 1.0 • Jan 2025</p>
-    </div>
-  </section>
+      /* ===== Hero ===== */
+      .masthead-hero {
+        padding: 120px 20px 80px;
+        text-align: center;
+        background: var(--gradient);
+        color: white;
+        border-radius: 0 0 50px 50px;
+      }
+      .masthead-hero h1 {
+        font-size: 2.5rem;
+        font-weight: 800;
+        margin-bottom: 15px;
+      }
+      .masthead-hero p {
+        max-width: 700px;
+        margin: auto;
+        font-size: 1.2rem;
+        opacity: 0.9;
+      }
 
-  <!-- Back to Top -->
-  <button id="backToTop">↑</button>
+      /* ===== Sections ===== */
+      .section {
+        max-width: 1100px;
+        margin: 80px auto;
+        padding: 0 20px;
+      }
+      .section h2 {
+        text-align: center;
+        font-size: 2rem;
+        margin-bottom: 40px;
+      }
+      .section h2::after {
+        content: "";
+        width: 60px;
+        height: 4px;
+        background: var(--primary);
+        display: block;
+        margin: 10px auto;
+        border-radius: 4px;
+      }
 
-  <!-- Footer -->
-  <!-- Modern Footer -->
-  <footer class="modern-footer" aria-label="Footer">
-    <div class="footer-top">
-      <div class="footer-brand footer-card">
-        <h3><i class="fas fa-book-open"></i> Research Paper Organizer</h3>
-        <p style=" margin-top: 20px;">Organize, track, and manage your research papers seamlessly.</p>
-      </div>
+      /* ===== Team Grid ===== */
+      .team-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+        gap: 30px;
+      }
+      .team-card {
+        background: var(--white);
+        border-radius: 16px;
+        padding: 20px;
+        text-align: center;
+        box-shadow: var(--shadow);
+        transition: all 0.3s;
+        opacity: 0;
+        transform: translateY(20px);
+      }
+      .team-card.show {
+        opacity: 1;
+        transform: translateY(0);
+      }
+      .team-card img {
+        width: 120px;
+        height: 120px;
+        border-radius: 50%;
+        object-fit: cover;
+        margin-bottom: 12px;
+        border: 4px solid #e0e7ff;
+      }
+      .team-card h3 {
+        font-size: 1.2rem;
+        margin-bottom: 5px;
+      }
+      .team-card p.role {
+        font-size: 0.9rem;
+        color: var(--text-light);
+        margin-bottom: 8px;
+      }
 
-      <div class="footer-links-section footer-card" >
-        <h4>Quick Links</h4>
-        <ul>
-          <li><a href="index.html"><i class="fas fa-home"></i>Home</a></li>
-          <li><a href="about.html"><i class="fas fa-users"></i>About Us</a></li>
-          <li><a href="contact.html"><i class="fas fa-envelope"></i>Contact</a></li>
-          <li><a href="Faq.html"><i class="fas fa-question-circle"></i>FAQ</a></li>
-        </ul>
-      </div>
+      /* ===== Contact ===== */
+      .contact {
+        text-align: center;
+        padding: 30px;
+        background: #eef6ff;
+        border-radius: 16px;
+      }
+      .contact a {
+        margin: 0 8px;
+        font-size: 1.5rem;
+        color: var(--primary);
+      }
 
-      <div class="footer-links-section footer-card">
-        <h4>Resources</h4>
-        <ul>
-          <li><a href="blog.html"><i class="fas fa-blog"></i>Blog</a></li>
-          <li><a href="glossary.html"><i class="fas fa-book"></i>Glossary</a></li>
-          <li><a href="open-source.html"><i class="fas fa-code-branch"></i>Open Source</a></li>
-           
-        </ul>
-      </div>
+      /* ===== Footer ===== */
+      .modern-footer {
+        background: linear-gradient(135deg, #1f3c88, #2c5aa0);
+        color: #fff;
+        padding: 60px 20px 20px;
+        border-radius: 25px 25px 0 0;
+      }
+      .footer-top {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        gap: 30px;
+        margin-bottom: 30px;
+      }
+      .footer-card h3,
+      .footer-card h4 {
+        margin-bottom: 15px;
+      }
+      .footer-links-section ul {
+        list-style: none;
+      }
+      .footer-links-section ul li {
+        margin: 10px 0;
+      }
+      .footer-links-section ul li a {
+        text-decoration: none;
+        color: #ddd;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        transition: all 0.3s ease;
+      }
+      .footer-links-section ul li a:hover {
+        color: #fff;
+        transform: translateX(5px);
+      }
+      .social-icons a {
+        font-size: 1.4rem;
+        margin-right: 15px;
+        color: #ddd;
+        background: rgba(255, 255, 255, 0.1);
+        padding: 10px;
+        border-radius: 50%;
+        transition: all 0.3s ease;
+      }
+      .social-icons a:hover {
+        color: #2c5aa0;
+        background: white;
+        transform: scale(1.2);
+      }
+      .footer-bottom {
+        text-align: center;
+        font-size: 0.9rem;
+        border-top: 1px solid rgba(255, 255, 255, 0.2);
+        padding-top: 15px;
+      }
+      .heart {
+        color: red;
+      }
+      /* Back to Top */
+      #backToTop {
+        position: fixed;
+        bottom: 30px;
+        right: 20px;
+        width: 50px;
+        height: 50px;
+        border-radius: 50%;
+        background: var(--gradient);
+        color: #fff;
+        border: none;
+        font-size: 20px;
+        display: none;
+        cursor: pointer;
+        box-shadow: var(--shadow);
+      }
 
-      <div class="footer-links-section footer-card">
-        <h4>Connect</h4>
-        <div class="social-icons">
-          <a href="https://github.com/supriya46788" target="_blank" title="GitHub"><i class="fab fa-github"></i></a>
-          <a href="https://www.linkedin.com/in/supriyapandey595" target="_blank" title="LinkedIn"><i class="fab fa-linkedin"></i></a>
-          <a href="mailto:supriyadpandey502@gmail.com" title="Email"><i class="fas fa-envelope"></i></a>
+      /* Responsive */
+      @media (max-width: 768px) {
+        .nav-links {
+          display: none;
+        }
+        .mobile-menu-toggle {
+          display: block;
+          font-size: 1.5rem;
+          cursor: pointer;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <!-- Navbar -->
+    <nav class="landing-nav">
+      <div class="nav-container">
+        <div class="nav-brand">
+          <i class="fas fa-book-open"></i> Research Paper Organizer
+        </div>
+        <div class="nav-links">
+          <a href="index.html">Home</a>
+          <a href="about.html">About</a>
+          <a href="tools.html">Tools</a>
+          <a href="contact.html">Contact</a>
+          <button class="btn-primary" onclick="location.href='signup.html'">
+            Get Started
+          </button>
+        </div>
+        <div class="mobile-menu-toggle"><i class="fas fa-bars"></i></div>
+        <div class="dark-toggle" id="darkToggle">
+          <i class="fas fa-moon"></i>
         </div>
       </div>
-    </div>
+    </nav>
 
-    <div class="footer-bottom">
-  © 2025 Research Paper Organizer | Made with <span class="heart">&hearts;</span> for researchers worldwide
-</div>
+    <!-- Hero -->
+    <section class="masthead-hero">
+      <h1>Meet the Minds Behind Research Paper Organizer</h1>
+      <p>
+        Our team of researchers, developers, and advisors is dedicated to
+        building smarter academic tools.
+      </p>
+    </section>
 
-  </footer>
+    <!-- Core Team -->
+    <section class="section">
+      <h2>Core Team</h2>
+      <div class="team-grid">
+        <div class="team-card">
+          <img
+            src="https://randomuser.me/api/portraits/women/44.jpg
+"
+          />
+          <h3>Dr. Sarah Lee</h3>
+          <p class="role">Lead Researcher</p>
+          <p>AI & NLP specialist with 10+ years of experience.</p>
+        </div>
+        <div class="team-card">
+          <img
+            src="https://randomuser.me/api/portraits/men/32.jpg
+"
+          />
+          <h3>Michael Chen</h3>
+          <p class="role">Full-Stack Developer</p>
+          <p>Passionate about scalable, user-friendly tools.</p>
+        </div>
+        <div class="team-card">
+          <img
+            src="https://randomuser.me/api/portraits/women/12.jpg
 
+"
+          />
+          <h3>Ananya Sharma</h3>
+          <p class="role">Product Designer</p>
+          <p>Creates intuitive, accessible academic tools.</p>
+        </div>
+      </div>
+    </section>
 
-  <script>
-    // Reveal animation
-    const cards = document.querySelectorAll(".team-card");
-    const observer = new IntersectionObserver(entries => {
-      entries.forEach(entry => { if(entry.isIntersecting) entry.target.classList.add("show"); });
-    }, { threshold: 0.2 });
-    cards.forEach(c => observer.observe(c));
+    <!-- Advisors -->
+    <section class="section">
+      <h2>Advisors</h2>
+      <div class="team-grid">
+        <div class="team-card">
+          <img
+            src="https://randomuser.me/api/portraits/men/82.jpg
+"
+          />
+          <h3>Prof. James Brown</h3>
+          <p class="role">Advisor</p>
+          <p>Expert in digital libraries & open-source research.</p>
+        </div>
+      </div>
+    </section>
 
-    // Back to Top
-    const backToTop = document.getElementById("backToTop");
-    window.addEventListener("scroll", () => { 
-      backToTop.style.display = window.scrollY > 150 ? "block" : "none"; 
-    });
-    backToTop.addEventListener("click", () => window.scrollTo({top:0, behavior:"smooth"}));
-  </script>
-</body>
+    <!-- Contact -->
+    <section class="section">
+      <h2>Contact & Info</h2>
+      <div class="contact">
+        <p>We’d love to hear from you. Reach out anytime!</p>
+        <a href="mailto:team@researchorganizer.com"
+          ><i class="fas fa-envelope"></i
+        ></a>
+        <a href="#"><i class="fab fa-github"></i></a>
+        <a href="#"><i class="fab fa-linkedin"></i></a>
+        <p style="margin-top: 10px; color: var(--text-light)">
+          Version 1.0 • Jan 2025
+        </p>
+      </div>
+    </section>
+
+    <!-- Back to Top -->
+    <button id="backToTop">↑</button>
+
+    <!-- Footer -->
+    <!-- Modern Footer -->
+    <footer class="modern-footer" aria-label="Footer">
+      <div class="footer-top">
+        <div class="footer-brand footer-card">
+          <h3><i class="fas fa-book-open"></i> Research Paper Organizer</h3>
+          <p style="margin-top: 20px">
+            Organize, track, and manage your research papers seamlessly.
+          </p>
+        </div>
+
+        <div class="footer-links-section footer-card">
+          <h4>Quick Links</h4>
+          <ul>
+            <li>
+              <a href="index.html"><i class="fas fa-home"></i>Home</a>
+            </li>
+            <li>
+              <a href="about.html"><i class="fas fa-users"></i>About Us</a>
+            </li>
+            <li>
+              <a href="contact.html"><i class="fas fa-envelope"></i>Contact</a>
+            </li>
+            <li>
+              <a href="Faq.html"><i class="fas fa-question-circle"></i>FAQ</a>
+            </li>
+          </ul>
+        </div>
+
+        <div class="footer-links-section footer-card">
+          <h4>Resources</h4>
+          <ul>
+            <li>
+              <a href="blog.html"><i class="fas fa-blog"></i>Blog</a>
+            </li>
+            <li>
+              <a href="glossary.html"><i class="fas fa-book"></i>Glossary</a>
+            </li>
+            <li>
+              <a href="open-source.html"
+                ><i class="fas fa-code-branch"></i>Open Source</a
+              >
+            </li>
+          </ul>
+        </div>
+
+        <div class="footer-links-section footer-card">
+          <h4>Connect</h4>
+          <div class="social-icons">
+            <a
+              href="https://github.com/supriya46788"
+              target="_blank"
+              title="GitHub"
+              ><i class="fab fa-github"></i
+            ></a>
+            <a
+              href="https://www.linkedin.com/in/supriyapandey595"
+              target="_blank"
+              title="LinkedIn"
+              ><i class="fab fa-linkedin"></i
+            ></a>
+            <a href="mailto:supriyadpandey502@gmail.com" title="Email"
+              ><i class="fas fa-envelope"></i
+            ></a>
+          </div>
+        </div>
+      </div>
+
+      <div class="footer-bottom">
+        © 2025 Research Paper Organizer | Made with
+        <span class="heart">&hearts;</span> for researchers worldwide
+      </div>
+    </footer>
+
+    <script>
+      // Reveal animation
+      const cards = document.querySelectorAll(".team-card");
+      const observer = new IntersectionObserver(
+        (entries) => {
+          entries.forEach((entry) => {
+            if (entry.isIntersecting) entry.target.classList.add("show");
+          });
+        },
+        { threshold: 0.2 }
+      );
+      cards.forEach((c) => observer.observe(c));
+
+      // Back to Top
+      const backToTop = document.getElementById("backToTop");
+      window.addEventListener("scroll", () => {
+        backToTop.style.display = window.scrollY > 150 ? "block" : "none";
+      });
+      backToTop.addEventListener("click", () =>
+        window.scrollTo({ top: 0, behavior: "smooth" })
+      );
+
+      // Dark mode toggle
+      const darkToggle = document.getElementById("darkToggle");
+      darkToggle.addEventListener("click", () => {
+        document.body.classList.toggle("dark-mode");
+
+        // Change icon
+        const icon = darkToggle.querySelector("i");
+        if (document.body.classList.contains("dark-mode")) {
+          icon.classList.replace("fa-moon", "fa-sun");
+        } else {
+          icon.classList.replace("fa-sun", "fa-moon");
+        }
+      });
+    </script>
+  </body>
 </html>

--- a/css/glossary.css
+++ b/css/glossary.css
@@ -1,6 +1,68 @@
 /* ===========================
    RESET
 =========================== */
+
+/* Example text inside glossary cards */
+body.dark-mode .glossary-item small {
+  color: #d1d5db;
+  background: #111827; /* soft gray so it's readable */
+}
+
+body.dark-mode .glossary-item strong {
+  color: #f9fafb;
+  background: #111827; /* brighter for "Example:" label */
+}
+
+
+/* Dark Mode Global */
+body.dark-mode {
+  background: #111827;
+  color: #f3f4f6;
+}
+
+/* Navbar */
+body.dark-mode .landing-nav {
+  background: rgba(31, 41, 55, 0.95);
+  border-bottom: 1px solid #374151;
+}
+body.dark-mode .nav-brand span,
+body.dark-mode .nav-links a {
+  color: #f3f4f6;
+}
+
+/* Header */
+body.dark-mode .glossary-header {
+  background: linear-gradient(135deg, #1e40af, #1e3a8a);
+  color: white;
+}
+body.dark-mode .glossary-header input {
+  background: #1f2937;
+  color: #f3f4f6;
+  border: 1px solid #374151;
+}
+
+/* Alphabet Nav */
+body.dark-mode .alphabet-nav a {
+  color: #f3f4f6;
+  background: #1f2937;
+  border: 1px solid #374151;
+}
+body.dark-mode .alphabet-nav a:hover {
+  background: #374151;
+}
+
+/* Glossary Items */
+body.dark-mode .glossary-item {
+  background: #1f2937;
+  border: 1px solid #374151;
+  color: #f3f4f6;
+}
+
+/* Footer */
+body.dark-mode .modern-footer {
+  background: linear-gradient(135deg, #0f172a, #1e293b);
+}
+
 * {
   margin: 0;
   padding: 0;

--- a/glossary.html
+++ b/glossary.html
@@ -30,7 +30,11 @@
             <div class="mobile-menu-toggle">
                 <i class="fas fa-bars"></i>
             </div>
+            <div id="darkModeToggle" class="dark-toggle">
+          <i class="fas fa-moon"></i>
         </div>
+        </div>
+       
     </nav>
   <header class="glossary-header">
     <a href="index.html" class="back-home">&larr; Back to Home</a>

--- a/js/glossary.js
+++ b/js/glossary.js
@@ -93,4 +93,26 @@ document.querySelector(".mobile-menu-toggle").addEventListener("click", () => {
   document.querySelector(".nav-links").classList.toggle("active");
 });
 
+const darkToggle = document.getElementById("darkModeToggle");
+const body = document.body;
+
+// Load preference
+if (localStorage.getItem("darkMode") === "enabled") {
+  body.classList.add("dark-mode");
+}
+
+// Toggle button
+darkToggle.addEventListener("click", () => {
+  body.classList.toggle("dark-mode");
+
+  if (body.classList.contains("dark-mode")) {
+    localStorage.setItem("darkMode", "enabled");
+    darkToggle.innerHTML = '<i class="fas fa-sun"></i>';
+  } else {
+    localStorage.setItem("darkMode", "disabled");
+    darkToggle.innerHTML = '<i class="fas fa-moon"></i>';
+  }
+});
+
+
 

--- a/open-source.html
+++ b/open-source.html
@@ -12,6 +12,27 @@ body{font-family:'Segoe UI',sans-serif;background:#f8fafc;color:#1e293b;line-hei
 a{text-decoration:none;color:inherit;}
 h1,h2,h3,h4{font-weight:600;}
 
+.dark-toggle {
+  position: fixed;
+  top: 20px;
+  right: 20px;
+  background: #fff;
+  border: 1px solid #cbd5e1;
+  border-radius: 30px;
+  padding: 8px 14px;
+  cursor: pointer;
+  font-size: 1rem;
+  color: #2563eb;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+  transition: 0.3s;
+  z-index: 1000;
+}
+.dark-toggle:hover {
+  transform: scale(1.05);
+  background: #e2e8f0;
+}
+
+
 /* Floating Back Button */
 .back-home {
   position:fixed;top:20px;left:20px;
@@ -150,13 +171,117 @@ footer.modern-footer {
   .controls input{width:100%;}
 }
 
+/* 🌙 Dark Mode Overrides */
+body.dark-mode {
+  background: #111827;
+  color: #f3f4f6;
+}
+
+/* Back button + toggle */
+body.dark-mode .back-home {
+  background: #1f2937;
+  color: #f3f4f6;
+  border-color: #374151;
+}
+
+/* Header */
+body.dark-mode header {
+  background: linear-gradient(145deg, #1e3a8a, #1e40af, #2563eb);
+  color: #f3f4f6;
+}
+body.dark-mode header h2 { color: #dbeafe; }
+body.dark-mode header::after { background: #111827; }
+
+/* Controls */
+body.dark-mode .controls input {
+  background: #1f2937;
+  color: #f3f4f6;
+  border: 1px solid #374151;
+}
+body.dark-mode .controls button {
+  background: #2563eb;
+  border-color: #2563eb;
+}
+body.dark-mode .controls button:hover {
+  background: #1d4ed8;
+}
+
+/* Repo Cards */
+body.dark-mode .repo {
+  background: #1f2937;
+  border: 1px solid #374151;
+  color: #f3f4f6;
+}
+body.dark-mode .repo h3 { color: #60a5fa; }
+body.dark-mode .repo p { color: #d1d5db; }
+body.dark-mode .repo a {
+  background: #2563eb;
+  color: #fff;
+}
+body.dark-mode .repo .tags span {
+  background: #3b82f6;
+  color: #f9fafb;
+}
+
+/* Contribute Section */
+body.dark-mode .contribute {
+  background: #1e293b;
+}
+body.dark-mode .contribute h2 { color: #60a5fa; }
+body.dark-mode .contribute-card {
+  background: #1f2937;
+  color: #f3f4f6;
+  border: 1px solid #374151;
+}
+body.dark-mode .contribute-card h3 { color: #60a5fa; }
+
+body.dark-mode .contribute-card p { color: #fff; }
+
+/* Acknowledge Section */
+body.dark-mode .acknowledge {
+  background: #111827;
+}
+body.dark-mode .ack-card {
+  background: linear-gradient(135deg, #2563eb, #1e40af);
+}
+
+/* Footer */
+body.dark-mode footer.modern-footer {
+  background: linear-gradient(135deg, #0f172a, #1e293b);
+  color: #f3f4f6;
+}
+body.dark-mode .footer-card {
+  background: #1f2937;
+  color: #f3f4f6;
+}
+body.dark-mode .footer-links-section ul li a {
+  color: #f3f4f6;
+}
+body.dark-mode .footer-links-section ul li a:hover {
+  color: #60a5fa;
+}
+body.dark-mode .social-icons a {
+  background: #1f2937;
+  color: #f3f4f6;
+}
+body.dark-mode .social-icons a:hover {
+  background: #2563eb;
+  color: #fff;
+}
+
+
 </style>
+
+
 </head>
 <body>
 
 <a href="index.html" class="back-home"><i class="fas fa-arrow-left"></i> Back</a>
-
+<div id="darkModeToggle" class="dark-toggle">
+          <i class="fas fa-moon"></i>
+        </div>
 <header>
+ 
   <h1>🌐 Open Source Community</h1>
   <h2>Discover Projects • Contribute • Grow</h2>
 </header>
@@ -269,6 +394,30 @@ function filterRepos(tag) {
   if(tag === "all") displayRepos(allRepos);
   else displayRepos(allRepos.filter(r => r.tags.includes(tag)));
 }
+
+// 🌙 Dark Mode Toggle
+const darkToggle = document.getElementById("darkModeToggle");
+const body = document.body;
+
+// Load preference
+if (localStorage.getItem("darkMode") === "enabled") {
+  body.classList.add("dark-mode");
+  darkToggle.innerHTML = '<i class="fas fa-sun"></i>';
+}
+
+// Toggle event
+darkToggle.addEventListener("click", () => {
+  body.classList.toggle("dark-mode");
+
+  if (body.classList.contains("dark-mode")) {
+    localStorage.setItem("darkMode", "enabled");
+    darkToggle.innerHTML = '<i class="fas fa-sun"></i>';
+  } else {
+    localStorage.setItem("darkMode", "disabled");
+    darkToggle.innerHTML = '<i class="fas fa-moon"></i>';
+  }
+});
+
 
 fetchRepos();
 </script>


### PR DESCRIPTION
📌 Changes
Implemented dark mode styling for the Open Source page masthead (header, repo cards, contribute section, acknowledgements, and footer consistency).
Added the Dark mode in the Glossary , Masthead , Open Source Pages.
Using the Sun Button You can Toggle the Dark Mode Vice versa

Updated Glossary page:
Glossary cards, example text, and content sections now adapt properly in dark mode.
Improved contrast for readability (titles, descriptions, example labels).

ScreenShots:
<img width="1331" height="631" alt="image" src="https://github.com/user-attachments/assets/2df63ab7-82b6-43ee-a488-9fc89a0146b2" />
<img width="1333" height="626" alt="image" src="https://github.com/user-attachments/assets/39e24ffe-10d6-4b1e-b311-522d4c908ee5" />
<img width="1336" height="642" alt="image" src="https://github.com/user-attachments/assets/e29d2d1b-d1c1-4979-a133-d876ee593a8f" />



✅ Result
Consistent dark theme across Open Source and Glossary pages.
Better readability, improved UI aesthetics in low-light environments.

Closes Issue #353 