### PR TITLE
Fix: Persist dark mode across Home page & testimonials (#319)

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,12 +75,14 @@
           <a href="about.html">About</a>
           <a href="tools.html">Tools</a>
           <a href="contact.html">Contact</a>
-          <button
-            class="btn-primary"
-            onclick="window.location.href='signup.html'"
-          >
+          <button class="btn-primary" onclick="window.location.href='signup.html'">
             Get Started
           </button>
+          <!-- Add dark mode toggle here -->
+          <button class="dark-toggle nav-item" id="darkModeToggle" title="Toggle Dark Mode">
+            <i class="fas fa-moon"></i>
+          </button>
+          
         </div>
 
         <div class="mobile-menu-toggle">
@@ -583,6 +585,40 @@
           font-size: 2rem;
         }
       }
+      /* ==== Dark mode fixes for Testimonials (append at end of testimonials <style>) ==== */
+body.dark-mode #testimonials {
+  background: #0f172a;           /* darker section bg */
+  color: #e5e7eb;
+}
+
+/* keep the side-fade mask but ensure opacity only, not light tint */
+body.dark-mode .testimonials-marquee {
+  -webkit-mask: linear-gradient(90deg, transparent, rgba(0,0,0,1) 10%, rgba(0,0,0,1) 90%, transparent);
+          mask: linear-gradient(90deg, transparent, rgba(0,0,0,1) 10%, rgba(0,0,0,1) 90%, transparent);
+}
+
+/* cards */
+body.dark-mode .testimonial-card {
+  background: #1f2937;           /* card bg */
+  color: #e5e7eb;                /* default text */
+  box-shadow: 0 8px 24px rgba(0,0,0,0.35);
+}
+body.dark-mode .testimonial-card:hover {
+  background: linear-gradient(135deg, #1f2937 0%, #111827 100%);
+  box-shadow: 0 16px 40px rgba(0,0,0,0.45);
+}
+
+/* inner text tones */
+body.dark-mode .testimonial-card h3 { color: #f3f4f6; }
+body.dark-mode .testimonial-card .designation { color: #9ca3af; }
+body.dark-mode .testimonial-card .feedback { color: #cbd5e1; }
+body.dark-mode .testimonial-card .tags { color: #93c5fd; }
+
+/* avatar ring */
+body.dark-mode .testimonial-card img {
+  border-color: #374151;
+}
+
     </style>
 
     <!-- ===== JS Marquee Enhancement ===== -->
@@ -953,6 +989,47 @@
         background: rgba(0, 0, 0, 0.3);
         border-top-color: rgba(224, 224, 224, 0.1);
       }
+
+      /* Dark mode toggle styles */
+      .dark-toggle {
+        background: none;
+        border: none;
+        color: inherit;
+        cursor: pointer;
+        padding: 8px;
+        font-size: 1.2rem;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        transition: transform 0.3s ease;
+      }
+
+      .dark-toggle:hover {
+        transform: scale(1.1);
+      }
+
+      /* Dark mode styles */
+      body.dark-mode {
+        background-color: #1a202c;
+        color: #e2e8f0;
+      }
+
+      body.dark-mode .landing-nav {
+        background-color: #2d3748;
+      }
+
+      body.dark-mode .nav-links a {
+        color: #e2e8f0;
+      }
+
+      body.dark-mode .feature-card {
+        background-color: #2d3748;
+        color: #e2e8f0;
+      }
+
+      body.dark-mode .feature-card p {
+        color: #cbd5e0;
+      }
     </style>
 
     <!-- Back to Top Button -->
@@ -1216,5 +1293,31 @@
         });
       });
     </script>
+    <script>
+  // Dark mode functionality
+  document.addEventListener('DOMContentLoaded', () => {
+    const darkModeToggle = document.getElementById('darkModeToggle');
+    const icon = darkModeToggle.querySelector('i');
+    
+    // Check for saved dark mode preference
+    if (localStorage.getItem('darkMode') === 'enabled') {
+      document.body.classList.add('dark-mode');
+      icon.classList.replace('fa-moon', 'fa-sun');
+    }
+    
+    darkModeToggle.addEventListener('click', () => {
+      document.body.classList.toggle('dark-mode');
+      
+      // Update icon and save preference
+      if (document.body.classList.contains('dark-mode')) {
+        icon.classList.replace('fa-moon', 'fa-sun');
+        localStorage.setItem('darkMode', 'enabled');
+      } else {
+        icon.classList.replace('fa-sun', 'fa-moon');
+        localStorage.setItem('darkMode', 'disabled');
+      }
+    });
+  });
+</script>
   </body>
 </html>

--- a/landing.css
+++ b/landing.css
@@ -1425,3 +1425,78 @@ body {
     box-shadow: none;
   }
 }
+/* ==== Dark Mode Overrides for Landing Page ==== */
+body.dark-mode {
+  background: var(--bg-dark);
+  color: var(--text-light);
+}
+
+/* Navigation */
+body.dark-mode .landing-nav {
+  background: rgba(17, 24, 39, 0.95); /* dark backdrop */
+  border-bottom-color: #374151;
+}
+body.dark-mode .nav-links a {
+  background: linear-gradient(135deg, #2563eb, #3b82f6);
+  color: #f3f4f6;
+}
+
+/* Hero */
+body.dark-mode .hero {
+  background: #0f172a;
+}
+body.dark-mode .hero-content h1,
+body.dark-mode .hero-content p,
+body.dark-mode .hero-note {
+  color: #e5e7eb;
+}
+body.dark-mode .hero-mockup {
+  background: #1f2937;
+}
+body.dark-mode .mockup-paper {
+  background: #111827;
+  border-left-color: #3b82f6;
+}
+body.dark-mode .paper-title,
+body.dark-mode .paper-meta {
+  color: #d1d5db;
+}
+
+/* Features */
+body.dark-mode .features {
+  background: #111827;
+}
+body.dark-mode .feature-card {
+  background: #1f2937;
+  color: #e5e7eb;
+}
+
+/* How it Works */
+body.dark-mode .how-it-works {
+  background: #0f172a;
+}
+body.dark-mode .step {
+  background: #1f2937;
+  color: #e5e7eb;
+}
+
+/* CTA */
+body.dark-mode .cta {
+  background: #111827;
+}
+body.dark-mode .cta-content h2,
+body.dark-mode .cta-content p {
+  color: #e5e7eb;
+}
+
+/* Footer */
+body.dark-mode .landing-footer {
+  background: #0b1120;
+  color: #e5e7eb;
+}
+body.dark-mode .footer-section a {
+  color: #9ca3af;
+}
+body.dark-mode .footer-section a:hover {
+  color: #3b82f6;
+}


### PR DESCRIPTION
**Description**
This PR fixes the issue where dark mode would reset on the Home page (index.html) while staying applied on other pages.
It also ensures that the Testimonials section now correctly follows dark mode styling.

**Changes Made**

- Added dark mode overrides at the bottom of landing.css for:
- Hero section
- Features section
- How It Works section
- CTA section
- Footer
- Patched inline CSS for Testimonials (index.html) so testimonial cards and background respect dark mode.
- Verified consistency of theme persistence across refresh and page navigation.
<img width="952" height="434" alt="{60C8D88B-97AA-46F0-83C9-74F3D3660F85}" src="https://github.com/user-attachments/assets/4848a5f6-a9ff-4855-80ce-75c3b393c8f3" />
