### PR TITLE
Text visible and in contrast with bg

### DIFF
--- a/landing.css
+++ b/landing.css
@@ -422,6 +422,9 @@ body {
   text-align: center;
   transition: all 0.3s ease;
 }
+#features .feature-card h3 {
+  color: #2563eb;
+}
 
 .feature-card:hover {
   transform: translateY(-5px);


### PR DESCRIPTION
## 🚀 Pull Request

### 🔖 Description
This PR addresses a UI/UX and accessibility issue where the heading text on the feature cards was nearly invisible due to low color contrast. The previous color made it difficult for users to read the titles of the feature

Fixes: # (issue number)
#391 
---

### 📸 Screenshots 
<img width="1391" height="809" alt="image" src="https://github.com/user-attachments/assets/785264e1-ed90-445f-b653-303c72df3af3" />

<img width="1398" height="808" alt="image" src="https://github.com/user-attachments/assets/769c01b8-5f8e-46a0-a467-8a25806f7c90" />

earlier it was like this:
<img width="1563" height="688" alt="image" src="https://github.com/user-attachments/assets/7f83e682-67f6-4bf8-9861-75187859e821" />


---

### ✅ Checklist

- [ ✅] My code follows the project’s guidelines and style.
- [✅ ] I have commented my code where necessary.
- [ ✅] I have updated the documentation if needed.
- [ ✅] I have tested the changes and confirmed they work as expected.
- [ ✅] My PR is linked to a GitHub issue.

