### PR TITLE
Fixed duplicate "Resources" block in footer section

### DIFF
--- a/index.html
+++ b/index.html
@@ -1113,23 +1113,6 @@ body.dark-mode .testimonial-card img {
                 ><i class="fas fa-code-branch"></i>Open Source</a
               >
             </li>
-          </ul>
-        </div>
-
-        <div class="footer-links-section footer-card">
-          <h4>Resources</h4>
-          <ul>
-            <li>
-              <a href="blog.html"><i class="fas fa-blog"></i>Blog</a>
-            </li>
-            <li>
-              <a href="glossary.html"><i class="fas fa-book"></i>Glossary</a>
-            </li>
-            <li>
-              <a href="open-source.html"
-                ><i class="fas fa-code-branch"></i>Open Source</a
-              >
-            </li>
             <li>
               <a href="Tag-Based-filtering.html"
                 ><i class="fas fa-book"></i>Tag Based Filtering</a


### PR DESCRIPTION
### 🔖 Description
This PR removes the duplicate "Resources" block that was being rendered twice in the footer section.
Fixes: #394
---

### 📸 Screenshots
<img width="1876" height="907" alt="Screenshot (52)" src="https://github.com/user-attachments/assets/cf7965c5-9e76-4e8d-9522-1d57d7b47840" />
---

### ✅ Checklist

- [X] My code follows the project’s guidelines and style.
- [X] I have tested the changes and confirmed they work as expected.
- [X] My PR is linked to a GitHub issue.
