### PR TITLE
Add animated counter for stats section

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -224,6 +224,28 @@ body.dark-mode .profile-container {
 .logout-btn:hover {
   background: #b91c1c;
 }
+.stats-grid {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  text-align: center;
+}
+
+.stat-number {
+  font-size: 2rem;
+  font-weight: bold;
+}
+
+.fade-in {
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 0.6s ease, transform 0.6s ease;
+}
+
+.fade-in.show {
+  opacity: 1;
+  transform: translateY(0);
+}
 
 @media (min-width: 768px) {
   .menu {

--- a/index.html
+++ b/index.html
@@ -30,6 +30,7 @@
         .catch((err) => console.error("SW registration failed:", err));
     });
   }
+  
 </script>
 
 <body>
@@ -259,27 +260,28 @@
 
   <!-- Stats Section -->
   <section class="stats fade-in">
-    <div class="container">
-      <div class="stats-grid">
-        <div class="stat-item fade-in">
-          <div class="stat-number">10,000+</div>
-          <div class="stat-label">Researchers</div>
-        </div>
-        <div class="stat-item fade-in">
-          <div class="stat-number">500,000+</div>
-          <div class="stat-label">Papers Organized</div>
-        </div>
-        <div class="stat-item fade-in">
-          <div class="stat-number">50+</div>
-          <div class="stat-label">Universities</div>
-        </div>
-        <div class="stat-item fade-in">
-          <div class="stat-number">99.9%</div>
-          <div class="stat-label">Uptime</div>
-        </div>
+  <div class="container">
+    <div class="stats-grid">
+      <div class="stat-item">
+        <div class="stat-number" data-target="10000">0</div>
+        <div class="stat-label">Researchers</div>
+      </div>
+      <div class="stat-item">
+        <div class="stat-number" data-target="500000">0</div>
+        <div class="stat-label">Papers Organized</div>
+      </div>
+      <div class="stat-item">
+        <div class="stat-number" data-target="50">0</div>
+        <div class="stat-label">Universities</div>
+      </div>
+      <div class="stat-item">
+        <div class="stat-number" data-target="99.9" data-decimals="1">0</div>
+        <div class="stat-label">Uptime (%)</div>
       </div>
     </div>
-  </section>
+  </div>
+</section>
+
 
   <!-- ===== Testimonials Section ===== -->
   <section id="testimonials">

--- a/landing.js
+++ b/landing.js
@@ -70,6 +70,32 @@ document.addEventListener("DOMContentLoaded", function () {
     });
   });
 });
+function animateCounter(el) {
+  const target = parseFloat(el.dataset.target);
+  const decimals = el.dataset.decimals ? parseInt(el.dataset.decimals) : 0;
+  let start = 0;
+  const duration = 2000; // 2 seconds
+  const step = (timestamp) => {
+    if (!el.startTime) el.startTime = timestamp;
+    const progress = Math.min((timestamp - el.startTime) / duration, 1);
+    const value = (progress * target).toFixed(decimals);
+    el.textContent = value + (decimals === 0 ? '+' : '');
+    if (progress < 1) requestAnimationFrame(step);
+  };
+  requestAnimationFrame(step);
+}
+
+const observer = new IntersectionObserver((entries) => {
+  entries.forEach(entry => {
+    if (entry.isIntersecting) {
+      entry.target.classList.add('show');
+      entry.target.querySelectorAll('.stat-number').forEach(animateCounter);
+      observer.unobserve(entry.target);
+    }
+  });
+}, { threshold: 0.3 });
+
+document.querySelectorAll('.stats').forEach(section => observer.observe(section));
 
 // Utility functions
 function scrollToSection(sectionId) {


### PR DESCRIPTION
## 🚀 Pull Request

### 🔖 Description
Turns the static numbers in the “Stats” block into a smooth count-up animation when the section scrolls into view.

###Changes
1. Added data-target (and optional data-decimals) attributes to each .stat-number
2. Vanilla JS using IntersectionObserver + requestAnimationFrame to:
3. trigger once when ~30% of the section is visible
4. increment numbers from 0 → target over ~2 s
5. handle decimals (e.g. 99.9)

Fixes: #405 
---

### 📸 Screenshots (if applicable)
Before
[counter-before.webm](https://github.com/user-attachments/assets/ac6974ed-a670-4eeb-96d7-043e8fe18834)
After
[counter.webm](https://github.com/user-attachments/assets/c914045c-36a5-4cf0-960f-3e300d276ed2)

---

### ✅ Checklist

- [✅] My code follows the project’s guidelines and style.
- [✅ ] I have commented my code where necessary.
- [✅ ] I have updated the documentation if needed.
- [✅ ] I have tested the changes and confirmed they work as expected.
- [✅ ] My PR is linked to a GitHub issue.

---

