### PR TITLE
feat: show loading thoughts only on first visit and skip on return

### DIFF
--- a/index.html
+++ b/index.html
@@ -1159,6 +1159,7 @@
     document.addEventListener("DOMContentLoaded", function () {
       const loadingScreen = document.getElementById("loading-screen");
       const loadingText = document.getElementById("loading-text");
+      
 
       const target = document.querySelector(".typing-text");
       const progressPercentage = document.querySelector(
@@ -1173,6 +1174,12 @@
 
       let index = 0;
       let progress = 0;
+
+      //changed: check if user has already seen the loading screen
+      const hasSeenLoading = localStorage.getItem("hasSeenLoading");
+
+      //changed: Only run loadinganimation if first-time visitor
+      if ( !hasSeenLoading ){
 
       // Enhanced text transition function
       function updateLoadingText() {
@@ -1220,6 +1227,9 @@
       setTimeout(() => {
         clearInterval(textInterval); // stop changing text
         loadingScreen.classList.add("hidden");
+
+        //changed: Mark that user has seen loading
+        localStorage.setItem("hasSeenLoading", "true");
         //Added typewriter effect in heading
         if (target) {
           const text = target.textContent;
@@ -1250,7 +1260,29 @@
           document.querySelector(".hero-image").classList.add("animate");
         }, 300);
       }, 6000); // adjust as needed
-    });
+    } else {
+      //changed: Skip loading entirely for returning visitors
+      loadingScreen.classList.add("hidden");
+
+      //Run typewriter effect and hero animations immediately
+      if (target) {
+      const text = target.textContent;
+      target.textContent = "";
+      let i = 0;
+      function typeWriter() {
+        if (i < text.length) {
+          target.textContent += text.charAt(i);
+          i++;
+          setTimeout(typeWriter, 80);
+        }
+      }
+      typeWriter();
+    }
+    document.querySelector(".hero-content").classList.add("animate");
+    document.querySelector(".hero-image").classList.add("animate");
+  } 
+});
+    
 
     //after executing slideright remove it so that other animation can start
     setTimeout(() => {


### PR DESCRIPTION
## 🚀 Pull Request

### 🔖 Description
Purpose:
This PR updates the homepage loading screen so that the “Organizing your thoughts” messages appear only on the user’s first visit. Returning visitors skip the loading screen and see the main content immediately.

Fixes: #402 


### ✅ Checklist

- [x] My code follows the project’s guidelines and style.
- [x] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [x] I have tested the changes and confirmed they work as expected.
- [x] My PR is linked to a GitHub issue.




