### PR TITLE
Fix inconsistent link count in "Resources" block across pages

### DIFF
--- a/Faq.html
+++ b/Faq.html
@@ -249,6 +249,9 @@
           <li><a href="blog.html"><i class="fas fa-blog"></i>Blog</a></li>
           <li><a href="glossary.html"><i class="fas fa-book"></i>Glossary</a></li>
           <li><a href="open-source.html"><i class="fas fa-code-branch"></i>Open Source</a></li>
+          <li>
+            <a href="Tag-Based-filtering.html"><i class="fas fa-book"></i>Tag Based Filtering</a>
+          </li>
         </ul>
       </div>
 

--- a/about.html
+++ b/about.html
@@ -1162,6 +1162,9 @@ border-top-color: rgba(224, 224, 224, 0.1);
           <li><a href="blog.html"><i class="fas fa-blog"></i>Blog</a></li>
           <li><a href="glossary.html"><i class="fas fa-book"></i>Glossary</a></li>
           <li><a href="open-source.html"><i class="fas fa-code-branch"></i>Open Source</a></li>
+          <li>
+            <a href="Tag-Based-filtering.html"><i class="fas fa-book"></i>Tag Based Filtering</a>
+          </li>
         </ul>
       </div>
 

--- a/blog.html
+++ b/blog.html
@@ -569,6 +569,9 @@ border-top-color: rgba(224, 224, 224, 0.1);
           <li><a href="blog.html"><i class="fas fa-blog"></i>Blog</a></li>
           <li><a href="glossary.html"><i class="fas fa-book"></i>Glossary</a></li>
           <li><a href="open-source.html"><i class="fas fa-code-branch"></i>Open Source</a></li>
+          <li>
+            <a href="Tag-Based-filtering.html"><i class="fas fa-book"></i>Tag Based Filtering</a>
+          </li>
         </ul>
       </div>
 

--- a/contact.html
+++ b/contact.html
@@ -306,6 +306,9 @@
           <li><a href="blog.html"><i class="fas fa-blog"></i>Blog</a></li>
           <li><a href="glossary.html"><i class="fas fa-book"></i>Glossary</a></li>
           <li><a href="open-source.html"><i class="fas fa-code-branch"></i>Open Source</a></li>
+          <li>
+            <a href="Tag-Based-filtering.html"><i class="fas fa-book"></i>Tag Based Filtering</a>
+          </li>
         </ul>
       </div>
 

--- a/tools.html
+++ b/tools.html
@@ -204,6 +204,9 @@
           <li><a href="blog.html"><i class="fas fa-blog"></i>Blog</a></li>
           <li><a href="glossary.html"><i class="fas fa-book"></i>Glossary</a></li>
           <li><a href="open-source.html"><i class="fas fa-code-branch"></i>Open Source</a></li>
+          <li>
+            <a href="Tag-Based-filtering.html"><i class="fas fa-book"></i>Tag Based Filtering</a>
+          </li>
         </ul>
       </div>
 


### PR DESCRIPTION
## 🚀 Pull Request

### 🔖 Description
This PR fixes the inconsistency in the footer’s "Resources" block, where some pages were showing only 3 links instead of the expected 4 links.

Fixes: #432

---

### 📸 Screenshot
<img width="1852" height="884" alt="Screenshot (60)" src="https://github.com/user-attachments/assets/1208b241-9afc-47f3-a0a1-e0df441b1d12" />

---

### ✅ Checklist

- [X] My code follows the project’s guidelines and style.
- [X] I have tested the changes and confirmed they work as expected.
- [X] My PR is linked to a GitHub issue.