### PR TITLE
Progress Bar Updated

### DIFF
--- a/signup.html
+++ b/signup.html
@@ -227,6 +227,24 @@
         });
       });
     });
+
+  //script for progress bar on sign-up page
+  const passwordInput = document.getElementById("signupPassword");
+  const passwordStrength = document.getElementById("passwordStrength");
+
+  passwordStrength.style.display = "none";
+
+  passwordInput.addEventListener("focus", () => {
+    passwordStrength.style.display = "block";
+  });
+
+  passwordInput.addEventListener("blur", () => {
+    passwordStrength.style.display = "none";
+  });
+
+  passwordInput.addEventListener("input", () => {
+    passwordStrength.style.display = "block";
+  });
   </script>
     
     <script src="js/auth.js"></script>


### PR DESCRIPTION
## 🚀 Pull Request

### 🔖 Description
The Progress bar on sign-up page of "Password" was visible all time before the changes. But now, It is only visible when the input of "Password" is selected and also visible when the input is given. But, after the password is written and another input is selected then it again gets hidden.

Fixes: #455 

---

### 📸 Screenshots (if applicable)
1. When the "Password" is not selected the progress bar is hidden.
<img width="1361" height="643" alt="progress 1" src="https://github.com/user-attachments/assets/4c2cfeb0-3e37-4eaa-b4be-7f1b91c895bd" />

2. When the "Password" is getting input, Progress-Bar is Visible.
<img width="1366" height="766" alt="Sign Up - Research Paper Organizer - Google Chrome 06-09-2025 16_31_11" src="https://github.com/user-attachments/assets/00403a8c-f27c-4631-a663-230db13506c7" />

3. When the "Password" is inputted and then the Progress-Bar gets hidden again.
<img width="1366" height="683" alt="progress 3" src="https://github.com/user-attachments/assets/64ea1690-0720-44fb-a764-017b8876911c" />


### ✅ Checklist

- [x] My code follows the project’s guidelines and style.
- [x] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [x] I have tested the changes and confirmed they work as expected.
- [x] My PR is linked to a GitHub issue.

---

### 🙌 Additional Notes
Now, Progress bar is not shown/visible all time and only visible when the input option is selected and it is enhancing the UI.
