### PR TITLE
Fix: UI for the Glossary Item Card in Dark Mode

### DIFF
--- a/css/glossary.css
+++ b/css/glossary.css
@@ -3,14 +3,24 @@
 =========================== */
 
 /* Example text inside glossary cards */
+
+body.dark-mode .glossary-item h2 {
+  color:#4CC9F0;
+}
+
+
+body.dark-mode .glossary-item p {
+  color:#D1D5DB;
+}
+
 body.dark-mode .glossary-item small {
-  color: #d1d5db;
-  background: #111827; /* soft gray so it's readable */
+  color: #E0E0E6;
+  background: #2A2D3E; /* soft gray so it's readable */
 }
 
 body.dark-mode .glossary-item strong {
   color: #f9fafb;
-  background: #111827; /* brighter for "Example:" label */
+  background: #2A2D3E; /* brighter for "Example:" label */
 }
 
 


### PR DESCRIPTION
## 🚀 Pull Request
Fixes #448 

### 🔖 Description
I have fixed the UI for the Glossary item cards in the dark mode by using a better contrast of colors.

Fixes: #448 

---

### 📸 Screenshots (if applicable)
Before:
<img width="1247" height="633" alt="image" src="https://github.com/user-attachments/assets/05d87aa8-ee4b-4fa4-8802-c124c051f0e9" />

After:
<img width="1247" height="633" alt="image" src="https://github.com/user-attachments/assets/0fb83495-467b-49aa-8b38-c31b2c19f1b4" />


---

### ✅ Checklist

- [ ✅] My code follows the project’s guidelines and style.
- [✅ ] I have commented my code where necessary.
- [ ✅] I have updated the documentation if needed.
- [✅ ] I have tested the changes and confirmed they work as expected.
- [ ✅] My PR is linked to a GitHub issue.

