### PR TITLE
Fix: Mobile Menu UI in Dark Mode

### DIFF
--- a/css/glossary.css
+++ b/css/glossary.css
@@ -91,7 +91,7 @@ body {
 =========================== */
 .landing-nav {
   width: 100%;
-  background: #fff;
+  background: rgba(255, 255, 255, 0.1);
   padding: 15px 30px;
   box-shadow: 0 2px 12px rgba(0,0,0,0.1);
   position: sticky;
@@ -125,6 +125,8 @@ body {
 .nav-brand:hover i {
   transform: rotate(20deg);
 }
+
+
 .nav-links a {
   margin: 0 12px;
   text-decoration: none;
@@ -622,10 +624,26 @@ body.dark-mode .footer-bottom {
 .menu-toggle span {
   width: 28px;
   height: 3px;
-  background: #357abd;
+  background: #3371af;
   border-radius: 2px;
   transition: 0.3s;
 }
+
+/* Navbar Mobile Dark Mode Fix */
+body.dark-mode .nav-links.active {
+  background: rgba(20, 20, 20,0.8);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.4);
+}
+
+body.dark-mode .nav-links.active a {
+  background-color: #1e3a8a;
+  color: #fff;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
+}
+
 
 /* Desktop */
 @media (min-width: 769px) {


### PR DESCRIPTION
## 🚀 Pull Request
Fixes #450 

### 🔖 Description
The Mobile Toggle Menu Ui and Links was not visible earlier, in the dark mode. Now it is fixed. 
Changes in css/glossary.css file

Fixes: #450 

---

### 📸 Screenshots (if applicable)
Before:
<img width="1302" height="720" alt="image" src="https://github.com/user-attachments/assets/76823dfb-add1-409d-8b44-4ffd2b468f4c" />

After:
<img width="1280" height="508" alt="image" src="https://github.com/user-attachments/assets/2751718a-abe8-47a5-a805-d391f5d27363" />


---

### ✅ Checklist

- [x] My code follows the project’s guidelines and style.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] I have tested the changes and confirmed they work as expected.
- [x] My PR is linked to a GitHub issue.

