### PR TITLE
fix: refresh papers list immediately when year filter changes (closes #470)

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -1426,42 +1426,60 @@ function importPapers() {
   input.click();
 }
 
-//Calendar Logic 
+// ===============================
+// 📅 Year Dropdown Logic (safe)
+// ===============================
 function populateYearSelect(id, startYear, endYear) {
-        const select = document.getElementById(id);
-        for (let year = startYear; year >= endYear; year--) {
-            const option = document.createElement("option");
-            option.value = year;
-            option.textContent = year;
-            select.appendChild(option);
-        }
-    }
+  const select = document.getElementById(id);
+  if (!select) return; // guard if element doesn't exist
 
+  // Keep existing placeholder if present
+  const first = select.querySelector("option:first-child");
+  select.innerHTML = "";
+  if (first && first.value === "") select.appendChild(first);
 
-    // Populate both dropdowns from 2050 → 1950
-const currentYear = new Date().getFullYear();
-populateYearSelect("minYear", currentYear, 1950);
-populateYearSelect("maxYear", currentYear, 1950);
-
-// Get the button
-const backToTopBtn = document.getElementById("backToTop");
-
-// Show button when scrolled down
-window.onscroll = function () {
-  if (document.body.scrollTop > 200 || document.documentElement.scrollTop > 200) {
-    backToTopBtn.style.display = "block";
-  } else {
-    backToTopBtn.style.display = "none";
+  for (let year = startYear; year >= endYear; year--) {
+    const option = document.createElement("option");
+    option.value = String(year);
+    option.textContent = String(year);
+    select.appendChild(option);
   }
-};
+}
 
-// Smooth scroll to top
-backToTopBtn.addEventListener("click", () => {
-  window.scrollTo({
-    top: 0,
-    behavior: "smooth"
-  });
+document.addEventListener("DOMContentLoaded", () => {
+  const currentYear = new Date().getFullYear();
+
+  // Populate existing dropdowns
+  populateYearSelect("minYear", currentYear, 1950);
+  // Only populate/bind maxYear if it exists in HTML
+  populateYearSelect("maxYear", currentYear, 1950);
+
+  const minEl = document.getElementById("minYear");
+  const maxEl = document.getElementById("maxYear");
+
+  if (minEl) minEl.addEventListener("change", filterPapers);
+  if (maxEl) maxEl.addEventListener("change", filterPapers);
+
+  // Optionally re-run once to reflect any default year selection
+  // (won’t hurt if values are empty)
+  filterPapers();
+
+  // ===============================
+  // 🔝 Back to Top Button Logic
+  // ===============================
+  const backToTopBtn = document.getElementById("backToTop");
+  if (backToTopBtn) {
+    window.addEventListener("scroll", () => {
+      const scrolled =
+        document.body.scrollTop > 200 || document.documentElement.scrollTop > 200;
+      backToTopBtn.style.display = scrolled ? "block" : "none";
+    });
+    backToTopBtn.addEventListener("click", () => {
+      window.scrollTo({ top: 0, behavior: "smooth" });
+    });
+  }
 });
+
 
 // Custom chatbot functionality removed - now using Chatbase integration
 


### PR DESCRIPTION
… #470)

## 🚀 Pull Request

### 🔖 Description

This PR fixes **Issue #470  – Year filter not updating immediately**.

- Previously, selecting a year did not refresh the papers list until another filter was changed.
- Added `onchange` event listeners for `minYear` (and `maxYear` if present).
- Now the papers list updates **instantly** when the year is selected.

**Fixes: #470 **

---

### 📸 Screenshots / screen recording (if applicable)

**Before:**  
User had to change another filter for year filter to apply.  

https://github.com/user-attachments/assets/9684f0b2-42aa-4908-9a6a-71bb58df0d9b


**After:**  
Papers refresh immediately when year is selected.  

https://github.com/user-attachments/assets/ec1dc8a9-d547-4f08-aa22-daf3cf6e6beb



### ✅ Checklist

- [ ✅] My code follows the project’s guidelines and style.
- [ ✅] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ✅] I have tested the changes and confirmed they work as expected.
- [ ✅] My PR is linked to a GitHub issue.

---

### 🙌 Additional Notes
- This fix is future-proof and won’t affect other filters.  
- Tested with multiple filters (topic, favorites, rating) — all work correctly.
