### PR TITLE
Removed back to home button from glossary page

### DIFF
--- a/glossary.html
+++ b/glossary.html
@@ -39,7 +39,6 @@
         </div>
     </nav>
   <header class="glossary-header">
-    <a href="index.html" class="back-home">&larr; Back to Home</a>
     <h1>📖 Research Glossary</h1>
     <p>Understand research terms with clear definitions and examples</p>
     <input type="text" id="searchBar" placeholder="Search for a term...">


### PR DESCRIPTION
## 🚀 Pull Request
Fix: Remove back to home button from glossary page

### 🔖 Description
Fixes: #483


---

### 📸 Screenshots 
Before:
The glossary page had two navigation buttons:

A "Home" button in the top navbar.

An extra "Back to Home" button at the bottom left.

<img width="1005" height="469" alt="Screenshot 2025-09-08 144632" src="https://github.com/user-attachments/assets/f54324d7-d8b0-4505-8337-477fb777c4b7" />

After:
The unnecessary "Back to Home" button has been removed, keeping only the navbar "Home" button.

<img width="1895" height="898" alt="image" src="https://github.com/user-attachments/assets/9576de89-1170-436f-8933-c372e1b3f0bc" />

---

### ✅ Checklist

- [✅] My code follows the project’s guidelines and style.
- [ ✅] I have commented my code where necessary.
- [✅ ] I have updated the documentation if needed.
- [✅ ] I have tested the changes and confirmed they work as expected.
- [ ✅] My PR is linked to a GitHub issue.

---

### 🙌 Additional Notes
This PR removes redundant UI from the glossary page, improving the user experience and keeping navigation consistent.
