### PR TITLE
Fix: Tag Based Filtering Link added to The Footer of Home Page

### DIFF
--- a/home.html
+++ b/home.html
@@ -1176,6 +1176,7 @@ box-shadow: rgba(0,0,0,0.8);
           <li><a href="blog.html"><i class="fas fa-blog"></i>Blog</a></li>
           <li><a href="glossary.html"><i class="fas fa-book"></i>Glossary</a></li>
           <li><a href="open-source.html"><i class="fas fa-code-branch"></i>Open Source</a></li>
+          <li><a href="Tag-Based-filtering.html"><i class="fas fa-book"></i>Tag Based Filtering</a></li>
         </ul>
       </div>
 


### PR DESCRIPTION
## 🚀 Pull Request
Fixes #486 
### 🔖 Description
Earlier the Tag Based Filtering Link was not present on the Home Page Footer.
It is now fixed

Fixes: #486 

---

### 📸 Screenshots (if applicable)
Before:
<img width="1280" height="396" alt="image" src="https://github.com/user-attachments/assets/b542b44b-747e-49fc-8ff9-69be495339af" />

After:
<img width="1280" height="396" alt="image" src="https://github.com/user-attachments/assets/6d219096-f22e-48c4-956a-9dccc7216660" />

---

### ✅ Checklist

- [x] My code follows the project’s guidelines and style.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] I have tested the changes and confirmed they work as expected.
- [x] My PR is linked to a GitHub issue.

---


