### PR TITLE
Made hamburger aligned horizontally to header

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -122,6 +122,44 @@ body {
   box-shadow: 0 6px 14px rgba(99, 102, 241, 0.3);
 }
 
+/* Mobile hamburger alignment fix */
+@media (max-width: 768px) {
+  .landing-nav .nav-container {
+    display: flex;
+    flex-direction: row !important;
+    align-items: center;
+    gap: 12px;
+    height: 56px;
+    padding-left: 12px;
+    padding-right: 12px;
+    flex-wrap: nowrap !important;
+  }
+  .nav-brand {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .mobile-menu-toggle {
+    margin-left: auto;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 44px;
+    height: 44px;
+    padding: 6px;
+    background: transparent;
+    border: none;
+    font-size: 22px;
+    color: var(--primary-dark);
+    border-radius: 8px;
+  }
+  .mobile-menu-toggle i {
+    pointer-events: none;
+    line-height: 1;
+    display: inline-block;
+  }
+}
+
 
 .nav-item:hover {
   background-color: #115cff; /* Slightly darker blue */
@@ -2577,16 +2615,3 @@ body.dark-mode .speed-control input:focus {
   cursor: pointer;
   color: #2563eb; /* matches your theme */
 }
-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 10px 15px;
-}
-
-header .hamburger {
-  font-size: 26px;
-  cursor: pointer;
-  color: #2563eb;
-}
-


### PR DESCRIPTION
## 🚀 Pull Request

### 🔖 Description
Fixed the mobile navigation so the hamburger menu button sits horizontally beside the logo/header, not below it.
Used CSS flexbox (flex-direction: row, align-items: center, flex-wrap: nowrap) on .nav-container to keep everything in one line.
Made the hamburger button (.mobile-menu-toggle) stay at the far right, vertically centered, and easy to tap.
Result: On mobile, the logo and hamburger are always side-by-side in the header.

Fixes: #621 

---

### 📸 Screenshots (if applicable)
<img width="557" height="738" alt="Screenshot 2025-09-19 181839" src="https://github.com/user-attachments/assets/580b9c44-bee1-452e-8fc8-b46ca18060e8" />


---

### ✅ Checklist

- [x] My code follows the project’s guidelines and style.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] I have tested the changes and confirmed they work as expected.
- [x] My PR is linked to a GitHub issue.

---

### 🙌 Additional Notes
<!-- Add anything else you’d like to mention (e.g., learning from this PR, challenges faced). -->
