### PR TITLE
🐛 [Bug Fix] Fix dark mode and layout issues on Add-Organize Papers page

### DIFF
--- a/add-organize-papers.html
+++ b/add-organize-papers.html
@@ -8,7 +8,7 @@
   </head>
   <body>
     <!-- Add Your Papers Section -->
-    <section class="Add-section">
+    <section id="add-section" class="add-section">
       <h2>➋ Add Your Papers</h2>
       <p>
         Upload PDFs, add paper details manually, or import from existing
@@ -26,7 +26,7 @@
     </section>
 
     <!-- Organize & Search Section -->
-    <section id="organize-section">
+    <section id="organize-section" class="organize-section">
       <h2>➌ Organize & Search</h2>
       <p>
         Use tags, topics, and ratings to organize your collection and find
@@ -48,6 +48,7 @@
         <div class="tag">Healthcare</div>
       </div>
     </section>
+
     <script>
       const fileInput = document.getElementById("fileUpload");
       const fileList = document.getElementById("fileList");
@@ -64,5 +65,25 @@
         });
       });
     </script>
+    <script>
+  const toggleBtn = document.getElementById('darkModeToggle');
+
+  // Check if user has a saved preference
+  if (localStorage.getItem('darkMode') === 'enabled') {
+    document.body.classList.add('dark-mode');
+  }
+
+  toggleBtn.addEventListener('click', () => {
+    document.body.classList.toggle('dark-mode');
+
+    // Save preference
+    if (document.body.classList.contains('dark-mode')) {
+      localStorage.setItem('darkMode', 'enabled');
+    } else {
+      localStorage.setItem('darkMode', 'disabled');
+    }
+  });
+</script>
+
   </body>
 </html>

--- a/css/add-organize-papers.css
+++ b/css/add-organize-papers.css
@@ -125,3 +125,65 @@ p {
   border: 1px solid #2563eb;
   box-shadow: 0 5px 20px rgba(0, 0, 0, 0.8);
 }
+
+/* ================= DARK MODE ================= */
+body.dark-mode {
+  background-color: #0f172a;
+  color: #e5e7eb;
+}
+
+body.dark-mode h2 {
+  color: #f3f4f6;
+}
+
+body.dark-mode p {
+  color: #cbd5e1;
+}
+
+/* Upload box */
+body.dark-mode .upload-box {
+  background: #1e293b;
+  border-color: #3b82f6;
+  color: #cbd5e1;
+}
+
+body.dark-mode .upload-box:hover {
+  background: #111827;
+}
+
+body.dark-mode .upload-box label {
+  background: #2563eb;
+  color: #fff;
+}
+
+body.dark-mode .upload-box label:hover {
+  background: #1d4ed8;
+}
+
+/* File list items */
+body.dark-mode .file-item {
+  background: #334155;
+  color: #f1f5f9;
+}
+
+/* Tags */
+body.dark-mode .tag {
+  background: #3b82f6;
+  color: #fff;
+}
+
+body.dark-mode .tag:hover {
+  background: #2563eb;
+}
+
+/* Search input */
+body.dark-mode #searchPapers {
+  background: #1e293b;
+  color: #e5e7eb;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+}
+
+body.dark-mode #searchPapers:focus {
+  border: 1px solid #3b82f6;
+  box-shadow: 0 5px 20px rgba(0, 0, 0, 0.8);
+}


### PR DESCRIPTION
Description:

Description

This pull request fixes the issue where dark mode was not being applied correctly on the Add & Organize Papers page. The main changes include updating the CSS for dark mode compatibility across the upload section, search input, file list, and tags. Additionally, a persistent dark mode toggle using localStorage has been added to remember user preference across sessions.

The issue was reported in [Issue #619 ] (replace with the actual issue number), and this PR resolves it by ensuring that all UI elements are properly styled in dark mode and the layout displays consistently.

Type of change
Bug fix

How Has This Been Tested?

Tested locally by toggling dark mode and verifying that the upload section, search bar, file list, and tags are displayed correctly.
Verified that file upload functionality works as expected in both light and dark modes.
Manually tested across multiple browsers (Chrome, Firefox) to ensure consistent behavior.
Ensured that no other sections or UI elements were affected by the changes.

Checklist

My code follows the project’s guidelines and style.
I have commented my code where necessary.
I have updated the documentation if needed.
I have tested the changes and confirmed they work as expected.
My PR is linked to a GitHub issue.

<img width="1915" height="910" alt="Screenshot 2025-09-20 205941" src="https://github.com/user-attachments/assets/d7f70bde-f8f2-4b53-b66d-372bff073aa0" />
<img width="1919" height="906" alt="Screenshot 2025-09-20 205949" src="https://github.com/user-attachments/assets/6cf755f8-9fd9-4887-9043-ae0393fd913d" />
<img width="1906" height="897" alt="Screenshot 2025-09-20 205958" src="https://github.com/user-attachments/assets/2400f34c-8834-4582-ab71-30b9b4ff1cd7" />

