### PR TITLE
made buttons visible in dark mode

### DIFF
--- a/css/auth.css
+++ b/css/auth.css
@@ -544,7 +544,6 @@ body.dark-mode .form-group label {
 }
 
 body.dark-mode .input-container input {
-  background: #111827;
   border-color: #374151;
   color: #f3f4f6;
 }


### PR DESCRIPTION
## 🚀 Pull Request

### 🔖 Description
This PR addresses the issue where **Font Awesome icons disappear or blend into the background in dark mode**, making them invisible to the user. The icons remain visible in light mode.  

Fixes: #617

---

### 📸 Screenshots (if applicable)
<img width="545" height="852" alt="Screenshot 2025-09-20 212426" src="https://github.com/user-attachments/assets/ea55868d-5c13-4642-b002-6a45ffb467d2" />


---

### ✅ Checklist

- [x] My code follows the project’s guidelines and style.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] I have tested the changes and confirmed they work as expected.
- [x] My PR is linked to a GitHub issue.

---

### 🙌 Additional Notes
The issue specifically occurs in **dark mode**, where Font Awesome icons become invisible or blend with the background. This PR ensures they remain visible in **light mode**, while highlighting the need to fix dark mode visibility.
