### PR TITLE
 [Bug Fix] Sticky navbar position for glossary, open source, and tag-…

### DIFF
--- a/css/Tag-Based-filtering.css
+++ b/css/Tag-Based-filtering.css
@@ -4,6 +4,7 @@ body {
   margin: 0;
   padding: 0;
   transition: background 0.3s, color 0.3s;
+  height:100vh;
 }
 
 .navbar {
@@ -12,6 +13,12 @@ body {
   align-items: center;
   padding: 1.5rem;
   flex-wrap: wrap;
+   position: sticky;
+  top: 0;
+  z-index: 1000;
+  background-color: #fff;
+  border-radius: 10px;
+  margin-bottom: 1.5rem;
 }
 
 .hamburger-container {

--- a/css/glossary.css
+++ b/css/glossary.css
@@ -2,12 +2,27 @@
    RESET
 =========================== */
 /* Nav-Links UI Fixed */
+body {
+  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+  background: #f4f7fb;
+  margin: 0;
+  padding: 0;
+  transition: background 0.3s, color 0.3s;
+  height:100vh;
+}
+
 .navbar {
   display: flex;
   justify-content: space-between;
   align-items: center;
   padding: 1.5rem;
   flex-wrap: wrap;
+   position: sticky;
+  top: 0;
+  z-index: 1000;
+  background-color: #fff;
+  border-radius: 10px;
+  margin-bottom: 1.5rem;
 }
 .hamburger-container {
   display: none;

--- a/css/open-source.css
+++ b/css/open-source.css
@@ -1,9 +1,24 @@
+body {
+  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+  background: #f4f7fb;
+  margin: 0;
+  padding: 0;
+  transition: background 0.3s, color 0.3s;
+  height:100vh;
+}
+
 .navbar {
   display: flex;
   justify-content: space-between;
   align-items: center;
   padding: 1.5rem;
   flex-wrap: wrap;
+   position: sticky;
+  top: 0;
+  z-index: 1000;
+  background-color: #fff;
+  border-radius: 10px;
+  margin-bottom: 1.5rem;
 }
 .hamburger-container {
   display: none;


### PR DESCRIPTION
This pull request fixes the issue where the sticky navbar position was not maintained when interacting with the glossary, open source section, and tag-based filtering . The main changes include updating the CSS to ensure the navbar remains correctly positioned across all interactions.

The issue was reported in [Issue #655 ] (replace with the actual issue number), and this PR resolves it by ensuring consistent navbar behavior while navigating these features.

Type of change
[x] Bug fix

How Has This Been Tested?
Tested locally by opening the glossary and verifying that the navbar remains sticky.
Applied tag-based filters and confirmed that the navbar does not shift or overlap content.
Checked the open source section for consistent navbar positioning.
Manually tested across multiple browsers (Chrome, Firefox) to ensure consistent behavior.

Checklist:
[x] My code follows the style guidelines of this project
[x] I have performed a self-review of my code
[x] I have commented my code where necessary
[x] I have added tests that prove my fix is effective or that my feature works
[x] I have made corresponding changes to the documentation if necessary

<img width="1914" height="912" alt="Screenshot 2025-09-22 102547" src="https://github.com/user-attachments/assets/7903ec73-5845-49dd-a072-9ff1ea720d15" />
<img width="1919" height="898" alt="Screenshot 2025-09-22 102601" src="https://github.com/user-attachments/assets/5d7c6d2d-d0b7-4674-b49e-eff651dc5898" />
<img width="1919" height="895" alt="Screenshot 2025-09-22 102611" src="https://github.com/user-attachments/assets/abaac594-e229-4a0d-bd5e-923fa082d61b" />

