### PR TITLE
✨ [Feature] Add chatbot widget for website navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -1867,6 +1867,16 @@
 
 
     </script>
+    <script>
+          const toggleDarkMode = () => {
+    document.body.classList.toggle('dark-mode');
+    localStorage.setItem(
+        'darkMode',
+        document.body.classList.contains('dark-mode') ? 'enabled' : 'disabled'
+    );
+};
+
+    </script>
 
     <script src="app.js"></script>
     

--- a/index.html
+++ b/index.html
@@ -1713,6 +1713,7 @@
             icon.classList.remove("fa-arrow-up");
             icon.classList.add("fa-arrow-down");
           }
+          
         } else {
           bottomToTopButton.style.display = "none";
         }

--- a/index.html
+++ b/index.html
@@ -704,6 +704,8 @@
       #testimonials:hover .testimonials-track {
         animation-play-state: paused !important;
       }
+
+      
     </style>
 
     <!-- ===== JS Marquee Enhancement ===== -->
@@ -897,6 +899,8 @@
         // Kick off
         init();
       })();
+
+
     </script>
 
     <script>
@@ -1363,12 +1367,108 @@
       body.dark-mode .steps-container .step-content p {
         color: #cbd5e1;
       }
+
+      /* Chatbot Styles */
+#chatbot {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  font-family: Arial, sans-serif;
+  z-index: 1000;
+}
+
+#chatbot-toggle {
+  background: #4a90e2;
+  color: #fff;
+  border: none;
+  border-radius: 50%;
+  width: 55px;
+  height: 55px;
+  font-size: 22px;
+  cursor: pointer;
+  box-shadow: 0 4px 10px rgba(0,0,0,0.2);
+}
+
+#chatbot-window {
+  width: 300px;
+  height: 380px;
+  background: #fff;
+  border-radius: 10px;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.2);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  margin-bottom: 10px;
+}
+
+.hidden {
+  display: none;
+}
+
+#chatbot-header {
+  background: #4a90e2;
+  color: #fff;
+  padding: 10px;
+  font-weight: bold;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+#chatbot-messages {
+  flex: 1;
+  padding: 10px;
+  overflow-y: auto;
+  font-size: 14px;
+}
+
+#chatbot-messages .msg {
+  margin-bottom: 8px;
+}
+
+#chatbot-messages .user {
+  text-align: right;
+  color: #333;
+}
+
+#chatbot-messages .bot {
+  text-align: left;
+  color: #4a90e2;
+}
+
+#chatbot-input {
+  border: none;
+  border-top: 1px solid #ddd;
+  padding: 10px;
+  font-size: 14px;
+  outline: none;
+}
+#chatbot-window {
+  position: absolute;
+  bottom: 70px;
+  right: 0;
+  z-index: 9999; /* ensure it's above other sections */
+}
+
     </style>
 
     <!-- Back to Top Button -->
     <button id="backToTop">
       <i class="fa-solid fa-arrow-up"></i>
     </button>
+
+    <!-- Chatbot Widget -->
+    <div id="chatbot">
+      <button id="chatbot-toggle">💬</button>
+      <div id="chatbot-window" class="hidden">
+      <div id="chatbot-header">
+      <span>Research Assistant</span>
+      <button id="chatbot-close">&times;</button>
+    </div>
+    <div id="chatbot-messages"></div>
+    <input type="text" id="chatbot-input" placeholder="Ask me to navigate..." />
+    </div>
+  </div>
 
     <!-- Modern Footer -->
     <footer class="modern-footer" aria-label="Footer">
@@ -1714,8 +1814,62 @@
       function closeSidebar() {
         document.getElementById("sidebar").style.width = "0";
       }
+
+      
+  document.addEventListener("DOMContentLoaded", () => {
+    const chatbotToggle = document.getElementById("chatbot-toggle");
+    const chatbotWindow = document.getElementById("chatbot-window");
+    const chatbotClose = document.getElementById("chatbot-close");
+    const chatbotInput = document.getElementById("chatbot-input");
+    const chatbotMessages = document.getElementById("chatbot-messages");
+
+    function addMessage(text, sender) {
+      const msg = document.createElement("div");
+      msg.classList.add("msg", sender);
+      msg.textContent = text;
+      chatbotMessages.appendChild(msg);
+      chatbotMessages.scrollTop = chatbotMessages.scrollHeight;
+    }
+
+    chatbotToggle.addEventListener("click", () => {
+      chatbotWindow.classList.toggle("hidden");
+    });
+
+    chatbotClose.addEventListener("click", () => {
+      chatbotWindow.classList.add("hidden");
+    });
+
+    chatbotInput.addEventListener("keypress", (e) => {
+      if (e.key === "Enter" && chatbotInput.value.trim() !== "") {
+        const userMsg = chatbotInput.value.trim();
+        addMessage(userMsg, "user");
+        chatbotInput.value = "";
+
+        // Command recognition
+        if (/about/i.test(userMsg)) {
+          addMessage("Opening About Page...", "bot");
+          window.location.href = "about.html";
+        } else if (/pdf/i.test(userMsg)) {
+          addMessage("Opening PDF Viewer...", "bot");
+          window.location.href = "pdf-viewer.html";
+        } else if (/feature/i.test(userMsg)) {
+          addMessage("Scrolling to Features...", "bot");
+          document.querySelector("#features").scrollIntoView({ behavior: "smooth" });
+        } else if (/contact/i.test(userMsg)) {
+          addMessage("Opening Contact Page...", "bot");
+          window.location.href = "contact.html";
+        } else {
+          addMessage("❓ Try: 'Go to About Page', 'Show Features', 'Open PDF Viewer'", "bot");
+        }
+      }
+    });
+  });
+
+
     </script>
 
     <script src="app.js"></script>
+    
+
   </body>
 </html>

--- a/signup.html
+++ b/signup.html
@@ -286,7 +286,16 @@
         passwordStrength.style.display = "block";
       });
     </script>
+    <script>
+         
+// Apply saved dark mode preference
+window.addEventListener('DOMContentLoaded', () => {
+    if(localStorage.getItem('darkMode') === 'enabled'){
+        document.body.classList.add('dark-mode');
+    }
+});
 
+    </script>
     <script type="module" src="js/auth.js"></script>
 
     <script src="js/form-validation.js"></script>

--- a/signup.html
+++ b/signup.html
@@ -288,6 +288,7 @@
     </script>
     <script>
          
+         
 // Apply saved dark mode preference
 window.addEventListener('DOMContentLoaded', () => {
     if(localStorage.getItem('darkMode') === 'enabled'){


### PR DESCRIPTION
🚀 Pull Request  

🔖 Description  
Added a floating chatbot widget to the Research Paper Organizer website.  
The chatbot allows users to navigate through the site using simple text commands like:  
- “Go to About Page” → redirects to `about.html`  
- “Open PDF Viewer” → redirects to `pdf-viewer.html`  
- “Show Features” → scrolls to `#features`  

Fixes: #669

---  

Screenshots 

https://github.com/user-attachments/assets/793012f2-77c9-4eef-aba2-baa01d2e2928

---  

Checklist  
- [x] My code follows the project’s guidelines and style.  
- [x] I have commented my code where necessary.  
- [x] I have updated the documentation if needed.  
- [x] I have tested the changes and confirmed they work as expected.  
- [x] My PR is linked to a GitHub issue.  

---  

 Additional Notes  
- This is a frontend-only implementation with no backend dependencies.  
- The chatbot improves accessibility and provides an alternative way to navigate the site.  