### PR TITLE
[Bug Fix] Navbar styling inconsistent on Research Glossary, Open Sour…

### DIFF
--- a/css/Tag-Based-filtering.css
+++ b/css/Tag-Based-filtering.css
@@ -20,10 +20,10 @@ body {
   border-radius: 10px;
   margin-bottom: 1.5rem;
 }
-
 .hamburger-container {
   display: none;
   flex-direction: column;
+  /* justify-content: center; */
   cursor: pointer;
   gap: 5px;
   padding: 10px;
@@ -36,48 +36,25 @@ body {
   transition: 0.3s;
 }
 
-body.dark-mode .hamburger-container .bar {
-  background-color: #e0e0e0;
-}
 
-/* Header */
-body.dark-mode .tag-b-f-header {
-  color: white;
-}
-
-/* Dark Mode Toggle */
-.toggle {
-  background: white;
-  border-radius: 6px;
+.dark-toggle {
+  color:#1a1a1a;
   border: none;
-  padding: 8px;
   cursor: pointer;
-  font-size: 16px;
-  box-shadow: 0px 2px 6px rgba(0, 0, 0, 0.1);
-  transition: background 0.3s;
+  padding: 0.6rem 1.2rem;
+  border-radius: 10px;
+  transition: all 0.25s ease;
+  }
+
+  .dark-mode .navbar {
+    background: rgba(17, 24, 39, 0.9);
+    border-bottom: 1px solid #374151;
 }
 
-/* ===== Dark mode styles ===== */
-body.dark-mode {
-  background: #0f172a;
-  color: #f8fafc;
-}
+  body.dark-mode .nav-item {
 
-body.dark-mode nav {
-  background: #1e293b;
-}
-
-body.dark-mode .paper {
-  background: #1e293b;
-  color: #f1f5f9;
-  border-top: 4px solid #60a5fa;
-}
-
-
-body.dark-mode .toggle {
-  background: #334155;
-  color: #f8fafc;
-}
+    color: #e0e0e0;
+  }
 
 /* Responsive Navbar */
 @media (max-width: 768px) {

--- a/css/glossary.css
+++ b/css/glossary.css
@@ -86,9 +86,10 @@ body {
     font-size: 1rem; 
   }
 }
+
+
 .dark-toggle {
   color:#1a1a1a;
-  background: #fff !important;
   border: none;
   cursor: pointer;
   padding: 0.6rem 1.2rem;
@@ -96,26 +97,17 @@ body {
   transition: all 0.25s ease;
   }
 
-  .dark-toggle:hover {
-  background: rgba(255, 255, 255, 0.1) !important;
-  }
-  body.dark-mode .navbar {
-    background: transparent;
-  }
+  .dark-mode .navbar {
+    background: rgba(17, 24, 39, 0.9);
+    border-bottom: 1px solid #374151;
+}
 
   body.dark-mode .nav-item {
-    background: linear-gradient(135deg, #4a5568, #2d3748);
+
     color: #e0e0e0;
   }
 
-  body.dark-mode .nav-item:hover {
-    background: linear-gradient(135deg, #63b3ed, #4299e1);
-    color: #1a202c;
-  }
-
-  body.dark-mode #darkModeToggle{
-  background-color: #2c2c2c  !important;   
-}
+  
 
 /* Example text inside glossary cards */
 

--- a/css/open-source.css
+++ b/css/open-source.css
@@ -36,6 +36,8 @@ body {
   transition: 0.3s;
 }
 
+
+
 /* Responsive styles */
 @media (max-width: 768px) {
   .hamburger-container {
@@ -84,7 +86,6 @@ body {
 }
 .dark-toggle {
   color:#1a1a1a;
-  background: #fff !important;
   border: none;
   cursor: pointer;
   padding: 0.6rem 1.2rem;
@@ -92,27 +93,16 @@ body {
   transition: all 0.25s ease;
   }
 
-  .dark-toggle:hover {
-  background: rgba(255, 255, 255, 0.1) !important;
-  }
-
-  body.dark-mode .navbar {
-    background: transparent;
-  }
+  .dark-mode .navbar {
+    background: rgba(17, 24, 39, 0.9);
+    border-bottom: 1px solid #374151;
+}
 
   body.dark-mode .nav-item {
-    background: linear-gradient(135deg, #4a5568, #2d3748);
+
     color: #e0e0e0;
   }
-
-  body.dark-mode .nav-item:hover {
-    background: linear-gradient(135deg, #63b3ed, #4299e1);
-    color: #1a202c;
-  }
-
-  body.dark-mode #darkModeToggle{
-  background-color: #2c2c2c  !important;   
-}
+  
 
 /* Example text inside open-source.html cards */
 
@@ -361,7 +351,7 @@ body.dark-mode .footer-bottom {
         transform: translateX(-50%);
         width: 80%;
         height: 60px;
-        background: #f8fafc;
+        background: transparent;
         border-radius: 50%;
         z-index: -1;
       }


### PR DESCRIPTION
Description
This pull request fixes the issue where the Navbar styling was inconsistent in dark mode across the Research Glossary, Open Source, and Tag-Based Filtering pages.
The main changes include updating the Navbar CSS to ensure consistent glassmorphism styling in both light and dark modes and aligning the design with the rest of the application.

The issue was reported in [Issue #663 ] (replace with the actual issue number), and this PR resolves it by ensuring that the Navbar renders correctly in dark mode across all affected pages.

Type of change
Bug fix

How Has This Been Tested?
Verified locally in dark mode on Research Glossary, Open Source, and Tag-Based Filtering pages.
Checked that Navbar styles now match the Contact Us page design.
Tested across multiple browsers (Chrome, Firefox, Edge) to ensure consistent behavior.
Ensured no regression in light mode UI.

Checklist:
 My code follows the style guidelines of this project
 I have performed a self-review of my code
 I have commented my code where necessary
 I have tested my fix to ensure it resolves the issue effectively
 I have verified that no other UI elements are negatively affected

<img width="1915" height="904" alt="Screenshot 2025-09-23 170355" src="https://github.com/user-attachments/assets/fd945d39-dc13-4cd4-9040-eb02076bccea" />
<img width="1919" height="907" alt="Screenshot 2025-09-23 170402" src="https://github.com/user-attachments/assets/b8f3a4b7-ee23-4461-a335-d5ca5fb3322a" />
<img width="1893" height="910" alt="Screenshot 2025-09-23 170413" src="https://github.com/user-attachments/assets/89783adc-458c-48c0-ad0b-851ceae80846" />
<img width="1877" height="904" alt="Screenshot 2025-09-23 170426" src="https://github.com/user-attachments/assets/8598c4dd-7c50-45b3-bdba-df8ce60bb1c7" />

