### PR TITLE
Bug Fix :  "Start your free trail" alignment issue from left to center

### DIFF
--- a/landing.css
+++ b/landing.css
@@ -204,6 +204,8 @@ body {
 .btn-primary.btn-large {
   background: var(--primary-dark);
   color: white;
+  display: flex;
+  justify-content: center;  
 }
 .btn-secondary {
   background: transparent;


### PR DESCRIPTION
## 🚀 Pull Request

### 🔖 Description
This PR fixes the "Start Your Free Trail" alignment issue and corrects the typo from "Left" → "Center".
Fixes: #701 

---

### 📸 Screenshots (if applicable)

<img width="1919" height="878" alt="Screenshot 2025-09-24 205306" src="https://github.com/user-attachments/assets/71055814-8743-44d0-90c6-ce0bb429753f" />

---

### ✅ Checklist

- [x] My code follows the project’s guidelines and style.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] I have tested the changes and confirmed they work as expected.
- [x] My PR is linked to a GitHub issue.

---

### 🙌 Additional Notes
Corrected the typo to improve professionalism.

Fixed alignment using CSS adjustments for better UI consistency.

Verified responsiveness across browsers and devices.
