### PR TITLE
Close preview feature added

### DIFF
--- a/add-organize-papers.html
+++ b/add-organize-papers.html
@@ -6,6 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Papers Page</title>
   <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   <link rel="stylesheet" href="./css/add-organize-papers.css" />
 </head>
 
@@ -53,6 +54,7 @@
     const fileInput = document.getElementById("fileUpload");
     const fileList = document.getElementById("fileList");
     const prevDiv = document.querySelector(".prevImage");
+
     fileInput.addEventListener("change", () => {
       fileList.innerHTML = ""; // clear old list
       prevDiv.innerHTML = "";
@@ -68,10 +70,10 @@
 
           const previewBtn = document.createElement("button");
           previewBtn.className = "preview-btn";
-          previewBtn.innerText = "👁️ Preview";
 
+          previewBtn.innerHTML = '<i class="fa fa-eye"></i> Preview';
           let previewImg;
-          
+
           if (file.type.startsWith("image/")) {
             previewImg = document.createElement("img");
             previewImg.className = "preview-img";
@@ -79,11 +81,18 @@
             previewImg = document.createElement("iframe");
             previewImg.className = "preview-frame preview-img";
           }
+          previewImg.style.display = "none";
 
           previewBtn.addEventListener("click", () => {
-            const fileURL = URL.createObjectURL(file);
-            previewImg.src = fileURL;
-            previewImg.style.display = "block";
+            if (previewImg.style.display === "none") {
+              const fileURL = URL.createObjectURL(file);
+              previewImg.src = fileURL;
+              previewImg.style.display = "block";
+              previewBtn.innerHTML = '<i class="fa fa-eye-slash"></i> Close Preview';
+            } else {
+              previewImg.style.display = "none";
+              previewBtn.innerHTML = '<i class="fa fa-eye"></i> Preview';
+            }
           });
 
           fileItem.appendChild(previewBtn);

--- a/css/add-organize-papers.css
+++ b/css/add-organize-papers.css
@@ -264,3 +264,26 @@ body.dark-mode #searchPapers:focus {
     transform: scale(1);
   }
 }
+.preview-btn {
+  background-color: #007bff;   /* blue background */
+  color: white;               /* white text */
+  border: none;               /* remove default border */
+  padding: 6px 12px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 500;
+  transition: background 0.3s ease;
+}
+
+.preview-btn.close::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 0;
+  width: 100%;
+  height: 2px;
+  background: red;
+  transform: rotate(-45deg);
+  background-color: #0056b3;  /* darker blue on hover */
+}


### PR DESCRIPTION
close : #736 
## 🚀 Pull Request

### 🔖 Description
- Added toggle functionality for the file preview button.
- Button now switches between:
  - 👁️ **Preview** (when hidden)
  - ❌ **Close Preview** (when shown)
- Preview content hides again when closed.
- Improved button visibility with CSS styling.

Fixes: # (736)

---

### 📸 Screenshots (if applicable)
<img width="600" height="683" alt="Screenshot (986)" src="https://github.com/user-attachments/assets/15b85504-9f5c-4c52-910a-37acccd7ba18" />


---

### ✅ Checklist

- [✅ ] My code follows the project’s guidelines and style.
- [✅ ] I have commented my code where necessary.
- [✅ ] I have updated the documentation if needed.
- [✅ ] I have tested the changes and confirmed they work as expected.
- [✅ ] My PR is linked to a GitHub issue.

---
