### PR TITLE
[BUG FIX] Styled elements properly in open source and tag based filtering page.

### DIFF
--- a/css/Tag-Based-filtering.css
+++ b/css/Tag-Based-filtering.css
@@ -162,15 +162,10 @@ body.dark-mode .filter-bar {
   border: 1px solid rgba(74, 85, 104, 0.3);
 }
 
-body.dark-mode .filter-btn {
-  background: linear-gradient(135deg, #4a5568, #2d3748);
-  color: #e0e0e0;
-  border: 1px solid rgba(74, 85, 104, 0.5);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
-}
 
-body.dark-mode .filter-btn:hover,
-body.dark-mode .filter-btn.active {
+
+body.dark-mode .filter-btn:hover
+ {
   background: linear-gradient(135deg, #63b3ed, #4299e1);
   color: #1a202c;
   box-shadow: 0 4px 15px rgba(99, 179, 237, 0.4);

--- a/css/open-source.css
+++ b/css/open-source.css
@@ -153,15 +153,7 @@ body.dark-mode .controls input {
   border: 1px solid #374151;
 }
 
-/* Alphabet Nav */
-body.dark-mode .controls button {
-  color: #f3f4f6;
-  background: #1f2937;
-  border: 1px solid #374151;
-}
-body.dark-mode .controls button:hover {
-  background: #374151;
-}
+
 
 /* Open-source Items */
 body.dark-mode .repo {


### PR DESCRIPTION
Description:
This pull request fixes the inconsistent Navbar styling in dark mode on the Research Glossary, Open Source, and Tag-Based Filtering pages.

The issue was reported in [Issue #708 ]  and this PR resolves it by ensuring all affected pages render correctly and consistently in dark mode.

Type of change
Bug fix

How Has This Been Tested?
Verified locally in dark mode on Research Glossary, Open Source, and Tag-Based Filtering pages.
Confirmed the unintended white background no longer appears on the Open Source page.
Checked that element styling is now consistent across Open Source and Tag-Based Filtering pages.
Tested across multiple browsers (Chrome, Firefox, Edge) to ensure consistent behavior.
Ensured no regressions in light mode UI.

Checklist:
 My code follows the style guidelines of this project
 I have performed a self-review of my code
 I have commented my code where necessary
 I have tested my fix to ensure it resolves the issue effectively
 I have verified that no other UI elements are negatively affected


https://github.com/user-attachments/assets/ed21813d-daaf-48f4-921b-818edc33707a


