### PR TITLE
Updated the Home UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -417,7 +417,7 @@
     </section>
 
     <!-- Stats Section -->
-    <section class="stats fade-in">
+    <section class="stats fade-in color">
       <div class="container">
         <div class="stats-grid">
           <div class="stat-item">
@@ -1373,6 +1373,32 @@ marquee.addEventListener("mouseleave", () => {
 
       body.dark-mode .steps-container .step-content p {
         color: #cbd5e1;
+      }
+
+      /* ==== Dark Mode Fixes for Stats Section ==== */
+      body.dark-mode .color{
+        background: #0f172a;
+      }
+      body.dark-mode .stat-item{
+        background: #1e293b;
+      }
+      .color{
+        background:white;
+      }
+      .stat-item{
+        background: #f9fafb;
+      }
+      .stat-number{
+        color:#3b82f6;
+      }
+      .stat-label{
+        color:#1e293b;
+      }
+      body.dark-mode .stat-label{
+        color:#e0e7ff;
+      }
+      body.dark-mode .stat-number{
+        color:#60a5fa;
       }
     </style>
 


### PR DESCRIPTION
## 🚀 Pull Request

### 🔖 Description

There is an section on the index/main page only which is having 4 cards with the "Researchers", "Papers Organized", "Universities" and "Uptime", it is having background as blue only for the dark and the light both mode with was breaking the UI of the page as it was not seen good. But, I have made the changes it the background color, text color, numbers color, different-different for the light and the dark mode.

Fixes: #726 

---

### 📸 Screenshots (if applicable)

In Light mode:-
<img width="1366" height="684" alt="image" src="https://github.com/user-attachments/assets/b0d31287-7820-4e6c-b457-c79abf3358a9" />

In Dark Mode:-
<img width="1366" height="681" alt="image" src="https://github.com/user-attachments/assets/1ffada80-c4eb-4891-841e-2e97d6db722e" />


---

### ✅ Checklist

- [ ] My code follows the project’s guidelines and style.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] I have tested the changes and confirmed they work as expected.
- [ ] My PR is linked to a GitHub issue.

---

### 🙌 Additional Notes
Now, the page is having consistent UI, which makes user experience more better.
