### PR TITLE
Bug fix : Light/Dark Mode button not functional on hemingway.html

### DIFF
--- a/hemingway.html
+++ b/hemingway.html
@@ -89,6 +89,21 @@
     }
 
     document.getElementById("analyzeBtn").addEventListener("click", analyzeText);
+
+    function toggleDarkMode() {
+      document.body.classList.toggle("dark-mode");
+      if (document.body.classList.contains("dark-mode")) {
+        localStorage.setItem("theme", "dark");
+      } else {
+        localStorage.setItem("theme", "light");
+      }
+    }
+
+    window.onload = function () {
+      if (localStorage.getItem("theme") === "dark") {
+        document.body.classList.add("dark-mode");
+      }
+    };
   </script>
 </body>
 </html>


### PR DESCRIPTION
## 🚀 Pull Request

### 🔖 Description
**This PR fixes the dark mode toggle icon issue on the hemingway.html page**
**Improves clarity for users to know which mode is currently active.**

---

### 📸 Screenshots (if applicable)

Attached in the issue raised regarding this

---

### ✅ Checklist

- [x] My code follows the project’s guidelines and style.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] I have tested the changes and confirmed they work as expected.
- [x] My PR is linked to a GitHub issue.

---

closes #754 
