### PR TITLE
Bug Fix: Uniform Gaps between blog cards in blog.html

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -396,18 +396,19 @@
   
   /* Blog Cards Hover Effects */
   .blog-container {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 20px; 
-    justify-content: flex-start;
-    align-items: flex-start;
-  }
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2rem;
+  justify-content: flex-start; 
+}
 
-  .blog-card {
-    flex: 1 1 300px; 
-    display: flex;
-    flex-direction: column;
-  }
+.blog-card {
+  flex: 1 1 300px; 
+  display: flex;
+  flex-direction: column;
+  align-items: stretch; 
+  min-height: 350px; 
+}
 
 
   .blog-card {

--- a/blog.html
+++ b/blog.html
@@ -395,6 +395,21 @@
   /* CUSTOM HOVER EFFECTS */
   
   /* Blog Cards Hover Effects */
+  .blog-container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 20px; 
+    justify-content: flex-start;
+    align-items: flex-start;
+  }
+
+  .blog-card {
+    flex: 1 1 300px; 
+    display: flex;
+    flex-direction: column;
+  }
+
+
   .blog-card {
     transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
     position: relative;


### PR DESCRIPTION
## 🚀 Pull Request

**This PR fixes the alignment issue for blog cards when filtering by category. Previously, the cards were centered with uneven gaps. Now, they are aligned to the left with uniform spacing.**


### 📸 Screenshots (if applicable)

Before : 
<img width="1919" height="866" alt="Screenshot 2025-09-29 221704" src="https://github.com/user-attachments/assets/a4f2db24-7918-4b01-9715-f810fc831345" />
After : 
<img width="1914" height="858" alt="Screenshot 2025-09-29 222123" src="https://github.com/user-attachments/assets/8e47da46-a4f1-43e7-88ef-95e056960316" />

---

### ✅ Checklist

- [x] My code follows the project’s guidelines and style.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] I have tested the changes and confirmed they work as expected.
- [x] My PR is linked to a GitHub issue.

---

🙌 Additional Notes

- CSS change: justify-content: center → justify-content: flex-start in .blog-container.
- This improves layout consistency for all filtered categories.

closes #770 
