### PR TITLE
Fix: changed home icon on tools page footer

### DIFF
--- a/tools.html
+++ b/tools.html
@@ -318,7 +318,7 @@
       <div class="footer-links-section footer-card" >
         <h4>Quick Links</h4>
         <ul>
-          <li><a href="index.html"><i class="fas fa-book-open"></i>Home</a></li>
+          <li><a href="index.html"><i class="fas fa-home"></i>Home</a></li>
           <li><a href="about.html"><i class="fas fa-users"></i>About Us</a></li>
           <li><a href="contact.html"><i class="fas fa-envelope"></i>Contact</a></li>
           <li><a href="Faq.html"><i class="fas fa-question-circle"></i>FAQ</a></li>


### PR DESCRIPTION
## 🚀 Pull Request

### 🔖 Description
Fixed the home icon on the footer of tools page.

Fixes: #763 

---

### 📸 Screenshots (if applicable)
before:
<img width="461" height="400" alt="before-tools" src="https://github.com/user-attachments/assets/fba358b1-ee41-439c-9500-4fba9ff9e191" />


after:
<img width="453" height="451" alt="after-tools" src="https://github.com/user-attachments/assets/0c06c142-6051-4979-ba62-c97676477633" />


---

### ✅ Checklist

- [x] My code follows the project’s guidelines and style.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [x] I have tested the changes and confirmed they work as expected.
- [x] My PR is linked to a GitHub issue.

---

### 🙌 Additional Notes
<!-- Add anything else you’d like to mention (e.g., learning from this PR, challenges faced). -->
