### PR TITLE
added glassy border

### DIFF
--- a/landing.css
+++ b/landing.css
@@ -1573,3 +1573,12 @@ body.dark-mode .footer-section a {
 body.dark-mode .footer-section a:hover {
   color: #3b82f6;
 }
+.feature-card.slide-left,
+    .feature-card.slide-right {
+      background: rgba(135, 206, 250, 0.15);
+      backdrop-filter: blur(10px);
+      -webkit-backdrop-filter: blur(10px);
+      border: 1px solid #1e90ff; /* Solid blue border */
+      border-radius: 10px; /* Rounded corners */
+      box-shadow: 0 4px 30px rgba(135, 206, 250, 0.1);
+    }


### PR DESCRIPTION
🚀 Pull Request
🔖 Description
My new card style has a darker blue border and a translucent light background, which gives it a clean look without any blur effect. It's a design that also works well for dark themes, providing a subtle and elegant visual style.

Fixes: # Issue No. 724

<img width="1680" height="962" alt="Screenshot 2025-10-03 at 3 37 16 PM" src="https://github.com/user-attachments/assets/d4577bad-e4e4-4fb0-832d-47200334f1c0" />
<img width="1680" height="964" alt="Screenshot 2025-10-03 at 3 37 38 PM" src="https://github.com/user-attachments/assets/17421e83-a487-4e18-a8b2-cdabbf3628db" />
