### PR TITLE
email input settings enabled in profile-settings page

### DIFF
--- a/profile-settings.html
+++ b/profile-settings.html
@@ -27,7 +27,7 @@
         <form id="profileForm">
             <section>
                 <h2>Account Information</h2>
-                <label>Email: <input type="email" id="email" name="email" disabled></label><br>
+                <label>Email: <input type="email" id="email" name="email"></label><br>
                 <label>Username: <input type="text" id="username" name="username"></label><br>
                 <button type="button" id="updateAccountBtn">Update Account</button>
             </section>


### PR DESCRIPTION
## 🚀 Pull Request

### 🔖 Description
I fixed the issue in email inputs which was disabled earlier and now it is enabled which allows the users to give input in the email.
Fixes: # issue no. 816
<img width="1676" height="962" alt="Screenshot 2025-10-06 at 4 57 09 PM" src="https://github.com/user-attachments/assets/1864c453-85fc-4df4-99a1-85fcee4170ef" />

