### PR TITLE
Removed home icon, standardize favicons, improved page titles

### DIFF
--- a/Faq.html
+++ b/Faq.html
@@ -42,7 +42,7 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="stylesheet" href="css/style.css">
-    <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
+    <link rel="shortcut icon" href="./favicon/favicon.ico" type="image/x-icon">
     <link rel="stylesheet" href="css/faq.css">
     <style>
          .navbar {
@@ -250,7 +250,6 @@ button#chatbase-bubble-button div {
         <!-- Navigation -->
         <nav class="navbar">
             <a href="index.html" class="nav-item">
-                <i class="fas fa-book-open"></i>
                 Home
             </a>
              <!-- Hamburger div (shows only on mobile) -->

--- a/Masthead.html
+++ b/Masthead.html
@@ -6,7 +6,7 @@
     <title>Masthead | Research Paper Organizer</title>
     <link rel="stylesheet" href="./css/style.css" />
     <link rel="stylesheet" href="landing.css" />
-    <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
+    <link rel="shortcut icon" href="./favicon/favicon.ico" type="image/x-icon">
     <link rel="stylesheet" href="css/style.css" />
     <link rel="stylesheet" href="landing.css" />
     <link

--- a/Pdfconverter.html
+++ b/Pdfconverter.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>PDF Converter</title>
-  <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
+  <title>Document Converter | Research Paper Organizer</title>
+  <link rel="shortcut icon" href="./favicon/favicon.ico" type="image/x-icon">
   <link rel="icon" href="./favicon/favicon-48x48.png" type="image/png" />
 
     <link

--- a/Tag-Based-filtering.html
+++ b/Tag-Based-filtering.html
@@ -4,14 +4,17 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-    <title>Research Paper Organiser - Tag Filtering</title>
+    <title>Smart Paper Filtering | Research Paper Organizer</title>
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
     />
     <link rel="stylesheet" href="./css/style.css" />
     <link rel="stylesheet" href="landing.css" />
-    <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
+    <link rel="shortcut icon" href="./favicon/favicon.ico" type="image/x-icon">
+    <link rel="icon" href="./favicon/favicon-48x48.png" type="image/png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="./favicon/apple-touch-icon.png" />
+    <link rel="manifest" href="./favicon/site.webmanifest" />
     <link rel="stylesheet" href="css/style.css" />
     <link rel="stylesheet" href="landing.css" />
     <link rel="stylesheet" href="css/open-source.css" />
@@ -21,7 +24,6 @@
     <!-- Navigation -->
     <nav class="navbar">
       <a href="index.html" class="nav-item">
-        <i class="fas fa-book-open"></i>
         Home
       </a>
       <!-- Hamburger div (shows only on mobile) -->

--- a/about.html
+++ b/about.html
@@ -45,7 +45,7 @@
     />
     <link rel="stylesheet" href="css/style.css" />
     <link rel="stylesheet" href="css/about.css" />
-    <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
+    <link rel="shortcut icon" href="./favicon/favicon.ico" type="image/x-icon">
     <style>
       /* Hamburger div style */
       .navbar {
@@ -1075,7 +1075,6 @@
 
       <nav class="navbar" aria-label="Primary">
         <a href="index.html" class="nav-item">
-          <i class="fas fa-book-open" aria-hidden="true"></i>
           <span>Home</span>
         </a>
         <!-- Hamburger div (shows only on mobile) -->

--- a/about_new.html
+++ b/about_new.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
   <link rel="stylesheet" href="css/style.css">
   <link rel="stylesheet" href="css/about.css">
-  <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
+  <link rel="shortcut icon" href="./favicon/favicon.ico" type="image/x-icon">
   <style>
     /* About page specific styles */
     .container {
@@ -496,7 +496,6 @@
     <!-- Navigation -->
     <nav class="navbar" aria-label="Primary">
       <a href="index.html" class="nav-item">
-        <i class="fas fa-book-open" aria-hidden="true"></i>
         <span>Home</span>
       </a>
 

--- a/add-organize-papers.html
+++ b/add-organize-papers.html
@@ -4,8 +4,8 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Papers Page</title>
-  <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
+  <title>Paper Management Dashboard | Research Paper Organizer</title>
+  <link rel="shortcut icon" href="./favicon/favicon.ico" type="image/x-icon">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   <link rel="stylesheet" href="./css/add-organize-papers.css" />
   <link rel="icon" href="./favicon/favicon-48x48.png" type="image/png" />

--- a/ats-checker.html
+++ b/ats-checker.html
@@ -3,11 +3,14 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>PDF Viewer & Annotator | Research Paper Organizer</title>
+    <title>ATS Resume Checker | Research Paper Organizer</title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
     <link rel="stylesheet" href="css/style.css">
     <link rel="stylesheet" href="css/ats-checker.css">
-    <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
+    <link rel="shortcut icon" href="./favicon/favicon.ico" type="image/x-icon">
+    <link rel="icon" href="./favicon/favicon-48x48.png" type="image/png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="./favicon/apple-touch-icon.png" />
+    <link rel="manifest" href="./favicon/site.webmanifest" />
     <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
     <script src="https://html2canvas.hertzen.com/dist/html2canvas.min.js"></script>
@@ -17,7 +20,6 @@
         <!-- Navigation -->
         <nav class="navbar">
             <a href="index.html" class="nav-item">
-                <i class="fas fa-book-open"></i>
                 Home
             </a>
 

--- a/auth-callback.html
+++ b/auth-callback.html
@@ -3,6 +3,10 @@
 <head>
     <meta charset="UTF-8">
     <title>Authenticating...</title>
+    <link rel="shortcut icon" href="./favicon/favicon.ico" type="image/x-icon">
+    <link rel="icon" href="./favicon/favicon-48x48.png" type="image/png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="./favicon/apple-touch-icon.png" />
+    <link rel="manifest" href="./favicon/site.webmanifest" />
     <style>
         body { font-family: sans-serif; background-color: #f0f2f5; text-align: center; padding-top: 50px; }
     </style>

--- a/blog.html
+++ b/blog.html
@@ -8,7 +8,7 @@
   <title>Blog | Research Paper Organizer</title>
   
 
-  <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
+  <link rel="shortcut icon" href="./favicon/favicon.ico" type="image/x-icon">
   <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" />
   <!-- Your global styles should remain as-is -->
@@ -670,7 +670,6 @@
     <!-- Navigation -->
     <nav class="navbar" aria-label="Primary">
       <a href="index.html" class="nav-item">
-        <i class="fas fa-book-open" aria-hidden="true"></i>
         <span>Home</span>
       </a>
       <div class="hamburger-container" onclick="toggleMenu()" aria-label="Toggle Menu">

--- a/contact.html
+++ b/contact.html
@@ -10,6 +10,7 @@
     />
     <link rel="stylesheet" href="css/contact.css" />
     <link rel="stylesheet" href="css/style.css" />
+    <link rel="shortcut icon" href="./favicon/favicon.ico" type="image/x-icon">
     <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
     <script src="https://cdn.jsdelivr.net/npm/@emailjs/browser@4/dist/email.min.js"></script>
     <link
@@ -183,7 +184,6 @@
       <!-- Navigation -->
       <nav class="navbar">
         <a href="index.html" class="nav-item">
-          <i class="fas fa-book-open"></i>
           Home
         </a>
         <div

--- a/forgot-password.html
+++ b/forgot-password.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Forgot Password</title>
-  <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
+  <link rel="shortcut icon" href="./favicon/favicon.ico" type="image/x-icon">
   <link rel="stylesheet" href="css/forgot-password.css" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <link rel="icon" href="./favicon/favicon-48x48.png" type="image/png" />

--- a/glossary.html
+++ b/glossary.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" />
   <link rel="stylesheet" href="./css/style.css" />
   <link rel="stylesheet" href="landing.css" />
-  <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
+  <link rel="shortcut icon" href="./favicon/favicon.ico" type="image/x-icon">
   <link rel="stylesheet" href="css/glossary.css" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" crossorigin="anonymous" />
   <link rel="icon" href="./favicon/favicon-48x48.png" type="image/png" />
@@ -31,7 +31,6 @@
       <!-- Navigation -->
    <nav class="navbar">
         <a href="index.html" class="nav-item">
-            <i class="fas fa-book-open"></i>
             Home
         </a>
        <!-- Hamburger div (shows only on mobile) -->

--- a/hemingway.html
+++ b/hemingway.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Hemingway Editor | Research Paper Organizer</title>
   <link rel="stylesheet" href="css/style.css">
-  <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
+  <link rel="shortcut icon" href="./favicon/favicon.ico" type="image/x-icon">
   <link rel="stylesheet" href="css/hemingway.css">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
@@ -31,7 +31,6 @@
     <!-- Navigation -->
     <nav class="navbar">
       <a href="index.html" class="nav-item">
-        <i class="fas fa-book-open"></i>
         Home
       </a>
       <div class="navbar-right-links">

--- a/home.html
+++ b/home.html
@@ -47,18 +47,12 @@
 <script>
   pdfjsLib.GlobalWorkerOptions.workerSrc = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.9.179/pdf.worker.min.js';
 </script>
-<link rel="apple-touch-icon" sizes="180x180" href="/favicon/apple-touch-icon.png" />
-  <link rel="icon" type="image/png" sizes="48x48" href="/favicon/favicon-48x48.png" />
-  <link rel="icon" type="image/png" sizes="16x16" href="/favicon/favicon-16x16.png" />
-  <link rel="manifest" href="/site.webmanifest" />
+  <link rel="shortcut icon" href="./favicon/favicon.ico" type="image/x-icon">
+  <link rel="icon" href="./favicon/favicon-48x48.png" type="image/png" />
+  <link rel="apple-touch-icon" sizes="180x180" href="./favicon/apple-touch-icon.png" />
+  <link rel="manifest" href="./favicon/site.webmanifest" />
   <link rel="stylesheet" href="css/style.css" />
-  <link rel="apple-touch-icon" sizes="180x180" href="/favicon/apple-touch-icon.png" />
-  <link rel="icon" type="image/png" sizes="48x48" href="/favicon/favicon-48x48.png" />
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon/favicon-32x32.png" />
-  <link rel="icon" type="image/png" sizes="16x16" href="/favicon/favicon-16x16.png" />
   <link rel="stylesheet" href="./css/removeFilterBtn.css">
-  <link rel="manifest" href="/site.webmanifest" />
-  <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
   <style>
     /* Ensure dark mode styles work */
     body.dark-mode {

--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
     <link rel="stylesheet" href="./css/style.css" />
     <link rel="stylesheet" href="landing.css" />
     <link rel="stylesheet" href="slider.css" />
-    <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
+    <link rel="shortcut icon" href="./favicon/favicon.ico" type="image/x-icon">
     <link rel="stylesheet" href="css/style.css" />
     <link rel="stylesheet" href="css/feedback.css" />
     <link rel="stylesheet" href="landing.css" />

--- a/login.html
+++ b/login.html
@@ -10,6 +10,7 @@
     />
     <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
     <link rel="stylesheet" href="css/auth.css" />
+    <link rel="shortcut icon" href="./favicon/favicon.ico" type="image/x-icon">
     <link rel="icon" href="./favicon/favicon-48x48.png" type="image/png" />
 
     <link

--- a/offline.html
+++ b/offline.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="description" content="Offline page for Research Paper Organizer — the app is unavailable without an internet connection." />
   <title>Offline — Research Paper Organizer</title>
-  <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
+  <link rel="shortcut icon" href="./favicon/favicon.ico" type="image/x-icon">
   <link rel="icon" href="./favicon/favicon-48x48.png" type="image/png" />
 
     <link

--- a/open-source.html
+++ b/open-source.html
@@ -5,10 +5,10 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Open Source Community</title>
+  <title>Open Source Project | Research Paper Organizer</title>
   <link rel="stylesheet" href="./css/style.css" />
   <link rel="stylesheet" href="landing.css" />
-  <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
+  <link rel="shortcut icon" href="./favicon/favicon.ico" type="image/x-icon">
   <link rel="stylesheet" href="css/style.css" />
   <link rel="stylesheet" href="landing.css" />
   <link rel="stylesheet" href="css/open-source.css">
@@ -35,7 +35,6 @@
   <!-- Navigation -->
   <nav class="navbar">
     <a href="index.html" class="nav-item">
-      <i class="fas fa-book-open"></i>
       Home
     </a>
     <!-- Hamburger div (shows only on mobile) -->

--- a/pdf-viewer.html
+++ b/pdf-viewer.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
     <link rel="stylesheet" href="css/pdf-viewer.css">
     <link rel="stylesheet" href="css/style.css">
-    <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
+    <link rel="shortcut icon" href="./favicon/favicon.ico" type="image/x-icon">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@simonwep/pickr/dist/themes/nano.min.css"/>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
@@ -33,7 +33,6 @@
         <!-- Navigation -->
         <nav class="navbar">
             <a href="index.html" class="nav-item">
-                <i class="fas fa-book-open"></i>
                 Home
             </a>
 

--- a/privacy.html
+++ b/privacy.html
@@ -8,7 +8,7 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
   <link rel="stylesheet" href="css/contact.css">
   <link rel="stylesheet" href="css/style.css">
-  <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
+  <link rel="shortcut icon" href="./favicon/favicon.ico" type="image/x-icon">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css"
     crossorigin="anonymous" />
   <link rel="icon" href="./favicon/favicon-48x48.png" type="image/png" />
@@ -273,7 +273,6 @@
     <!-- Navigation -->
     <nav class="navbar">
       <a href="index.html" class="nav-item">
-        <i class="fas fa-book-open"></i>
         Home
       </a>
       <div class="hamburger-container" onclick="toggleMenu()" aria-label="Toggle Menu">

--- a/profile-settings.html
+++ b/profile-settings.html
@@ -3,9 +3,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>User Profile & Settings</title>
+    <title>Account Settings | Research Paper Organizer</title>
     <link rel="stylesheet" href="css/profile-settings.css">
-    <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
+    <link rel="shortcut icon" href="./favicon/favicon.ico" type="image/x-icon">
     <link rel="icon" href="./favicon/favicon-48x48.png" type="image/png" />
 
     <link

--- a/profile.html
+++ b/profile.html
@@ -3,9 +3,12 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>User Profile & Settings</title>
+  <title>User Profile | Research Paper Organizer</title>
   <link rel="stylesheet" href="css/style.css">
-  <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
+  <link rel="shortcut icon" href="./favicon/favicon.ico" type="image/x-icon">
+  <link rel="icon" href="./favicon/favicon-48x48.png" type="image/png" />
+  <link rel="apple-touch-icon" sizes="180x180" href="./favicon/apple-touch-icon.png" />
+  <link rel="manifest" href="./favicon/site.webmanifest" />
   <script src="https://kit.fontawesome.com/yourkit.js" crossorigin="anonymous"></script>
 </head>
 <body>

--- a/roadmap.html
+++ b/roadmap.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Project Roadmap</title>
-  <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
+  <title>Development Roadmap | Research Paper Organizer</title>
+  <link rel="shortcut icon" href="./favicon/favicon.ico" type="image/x-icon">
   <link rel="icon" href="./favicon/favicon-48x48.png" type="image/png" />
 
   <link

--- a/signup.html
+++ b/signup.html
@@ -8,7 +8,7 @@
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"
     />
-    <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
+    <link rel="shortcut icon" href="./favicon/favicon.ico" type="image/x-icon">
     <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
     <link rel="stylesheet" href="css/auth.css" />
 

--- a/summarize.html
+++ b/summarize.html
@@ -3,8 +3,11 @@
 <head>
   <meta charset="UTF-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <title>AI Research Paper Assistant</title>
-  <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
+  <title>AI Paper Summarizer | Research Paper Organizer</title>
+  <link rel="shortcut icon" href="./favicon/favicon.ico" type="image/x-icon">
+  <link rel="icon" href="./favicon/favicon-48x48.png" type="image/png" />
+  <link rel="apple-touch-icon" sizes="180x180" href="./favicon/apple-touch-icon.png" />
+  <link rel="manifest" href="./favicon/site.webmanifest" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"/>
   <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
   <style>

--- a/terms-of-service.html
+++ b/terms-of-service.html
@@ -8,7 +8,10 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
   <link rel="stylesheet" href="css/contact.css">
   <link rel="stylesheet" href="css/style.css">
-  <link rel="shortcut icon" href="favicon/favicon.ico" type="image/x-icon">
+  <link rel="shortcut icon" href="./favicon/favicon.ico" type="image/x-icon">
+  <link rel="icon" href="./favicon/favicon-48x48.png" type="image/png" />
+  <link rel="apple-touch-icon" sizes="180x180" href="./favicon/apple-touch-icon.png" />
+  <link rel="manifest" href="./favicon/site.webmanifest" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css"
     crossorigin="anonymous" />
   <style>
@@ -263,7 +266,6 @@
     <!-- Navigation -->
     <nav class="navbar">
       <a href="index.html" class="nav-item">
-        <i class="fas fa-book-open"></i>
         Home
       </a>
       <div class="hamburger-container" onclick="toggleMenu()" aria-label="Toggle Menu">

--- a/tools.html
+++ b/tools.html
@@ -41,7 +41,7 @@
 <meta name="msapplication-TileColor" content="#2563eb" />
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
 <link rel="stylesheet" href="css/tool.css" />
-<link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
+<link rel="shortcut icon" href="./favicon/favicon.ico" type="image/x-icon">
 <link rel="stylesheet" href="css/style.css">
 <style>
   .navbar {
@@ -130,7 +130,6 @@
     <!-- Navigation -->
     <nav class="navbar">
         <a href="index.html" class="nav-item">
-            <i class="fas fa-book-open"></i>
             Home
         </a>
        <!-- Hamburger div (shows only on mobile) -->


### PR DESCRIPTION
## Title
Removed home icon from navbar, standardize favicons and improve page titles across all pages

## 🚀 Pull Request

### 🔖 Description
Standardized the favicon setup across all 29 HTML pages in your Research Paper Organizer project. This involved fixing incorrect favicon paths, Updated 9 key pages with professional, branded titles that include consistent "| Research Paper Organizer" branding - most notably fixing the ATS Checker page which had a completely wrong title ("PDF Viewer & Annotator" instead of "ATS Resume Checker"), These changes ensure your website now has universal browser support for favicons, consistent professional branding across all pages, and a polished user experience with clear tab identification in browsers.

Fixes: #819

---

### 📸 Screenshots (if applicable)
<img width="377" height="150" alt="Screenshot 2025-10-06 at 8 00 33 PM" src="https://github.com/user-attachments/assets/affffdb4-e4cd-4dea-9b1c-f6480e2a5a47" />
<img width="499" height="241" alt="Screenshot 2025-10-06 at 7 59 44 PM" src="https://github.com/user-attachments/assets/0b39c55b-5ebd-49e1-b471-ba0ffb0e5b52" />

---

### ✅ Checklist

- [x] My code follows the project’s guidelines and style.
- [x] I have tested the changes and confirmed they work as expected.
- [x] My PR is linked to a GitHub issue.
