### PR TITLE
Privacy Policy Section Updated

### DIFF
--- a/privacy.html
+++ b/privacy.html
@@ -63,7 +63,7 @@
   font-size: 2.5rem;
   font-weight: 800;
   margin-bottom: 15px;
-  color: #ffffff; /* No need for !important unless overridden */
+  color: #2c5aa0; /* No need for !important unless overridden */
   opacity: 1; /* Fully opaque */
   text-shadow: 2px 2px 0 rgba(237, 231, 231, 0.6); /* Reduce or remove blur */
 }
@@ -265,6 +265,45 @@
         padding: 15px;
       }
     }
+    
+  .privacy-hero {
+    display: flex;
+    flex-direction: column;
+    align-items: center; 
+    justify-content: center; 
+    text-align: center; 
+  }
+
+  .privacy-hero{
+    background: #FFFFFF;
+  }
+  .privacy-hero .hero-title {
+    font-size: 2.5rem;
+    font-weight: 800;
+    margin-bottom: 15px;
+    color: #2c5aa0 !important;
+    text-shadow: none; 
+  }
+
+  .privacy-hero .hero-subtitle {
+    font-size: 1.2rem;
+    color: #000000 !important; 
+    opacity: 1;
+    text-shadow: none;
+  }
+
+  .dark-mode .privacy-hero{
+    background: #2d3748;
+  }
+
+  body.privacy-hero .hero-title {
+    color: #2c5aa0 !important;
+  }
+
+  body.dark-mode .privacy-hero .hero-subtitle {
+    color: #ffffff !important;
+  }
+
   </style>
 </head>
 
@@ -296,7 +335,7 @@
     <div class="privacy-hero">
       <div class="hero-content">
         <h1 class="hero-title">Privacy Policy</h1>
-        <p class="hero-subtitle">Your privacy is important to us. This policy outlines how we collect, use, and protect your information.</p>
+        <p class="hero-subtitle"><b>Your privacy is important to us. This policy outlines how we collect, use, and protect your information.</b></p>
       </div>
     </div>
 


### PR DESCRIPTION
## 🚀 Pull Request

### 🔖 Description
Earlier, On the privacy policy page, on the first section, it was fully aligned towards the left as well as the section was not having any effect of the light/dark toggle. But, now the section has been centered, well as well as the light/dark toggle is working for the that section too, in which the background color and the text color respectively to the light/dark option.

Fixes: #856 

---

### 📸 Screenshots (if applicable)
In Light mode:- 
<img width="1366" height="685" alt="policy 2" src="https://github.com/user-attachments/assets/94398035-0fc8-4d16-804b-f1396eb32a55" />

In Dark mode:-
<img width="1366" height="684" alt="policy 1" src="https://github.com/user-attachments/assets/27a0d49c-32a9-4ab1-9862-da1b7bdeedc8" />


---

### ✅ Checklist

- [x] My code follows the project’s guidelines and style.
- [x] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [x] I have tested the changes and confirmed they work as expected.
- [x] My PR is linked to a GitHub issue.

---

### 🙌 Additional Notes
Earlier, as this is the first section on the page it was ruining the UI and was also putting bad impression on user, but, now it is perfectly aligned to the UI of the page and is enhancing the user experience.
