### PR TITLE
added color change

### DIFF
--- a/css/ats-checker.css
+++ b/css/ats-checker.css
@@ -61,6 +61,9 @@ p.lead {
   margin: 0 0 16px;
   color: blue;
 }
+body.dark-mode p.lead {
+  color:#60a5fa;
+}
 .card {
   background: var(--card);
   padding: 14px;
@@ -86,6 +89,10 @@ label {
   font-weight: 700;
   color: #000000; 
   margin-bottom: 6px;
+}
+
+body.dark-mode .heading {
+  color: #ffffff;
 }
 
 .controls {


### PR DESCRIPTION
## 🚀 Pull Request

### 🔖 Description
This PR fixes the text visibility issue in Dark Mode for the ATS Resume Checker. Previously, the heading text appeared black (#000) on a dark background, making it invisible or hard to read.  

This change ensures that in Dark Mode, the text color is automatically adjusted to a light color to maintain readability.

Fixes: #861

### 📸 Screenshots (if applicable)

<img width="1919" height="911" alt="Screenshot 2025-10-14 205511" src="https://github.com/user-attachments/assets/65b858a4-2aad-4632-a7f4-00a33cd06a46" />

---

### ✅ Checklist

- [x] My code follows the project’s guidelines and style.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] I have tested the changes and confirmed they work as expected.
- [x] My PR is linked to a GitHub issue.

---

### 🙌 Additional Notes
- Used a CSS selector targeting `.heading` inside `body.dark-mode` to override text color only in Dark Mode.
- Did not alter other heading styles (font size, alignment, margin) to preserve design consistency.
- Learned about proper CSS descendant selectors (`body.dark-mode .heading`) to handle theme-specific overrides.
