### PR TITLE
Contact us Section on Privacy Policy Updated

### DIFF
--- a/privacy.html
+++ b/privacy.html
@@ -304,6 +304,27 @@
     color: #ffffff !important;
   }
 
+  .contact-info{
+    background: #FFFFFF;
+  }
+
+  .contact-info h3{
+    color: #2c5aa0 !important;
+  }
+
+  .contact-info p, .contact-info a {
+    color: #000000 !important;
+  }
+
+  .dark-mode .contact-info{
+    background: #2d3748;
+  }
+  .dark-mode .contact-info h3{
+    color: #90cdf4 !important;
+  }
+  .dark-mode .contact-info p, .dark-mode .contact-info a {
+    color: #cbd5e1 !important;
+  }
   </style>
 </head>
 


### PR DESCRIPTION
## 🚀 Pull Request

### 🔖 Description
Earlier, the contact us section on the Privacy Policy page was not responding to the light/dark toggle button, due to which the color of the background as well as the text was not changing which was breaking the UI of the page. But, now the contact us section changes the background color as well as the text color when the light/dark toggle button is used, it is now enhancing the page UI as it blends with other page.

Fixes: #868 

---

### 📸 Screenshots (if applicable)
In Light Mode:- 
<img width="1366" height="683" alt="imp 1" src="https://github.com/user-attachments/assets/87387852-424b-482c-9cad-34fa7983da94" />

In Dark Mode:-
<img width="1366" height="683" alt="imp 2" src="https://github.com/user-attachments/assets/dd9ab8d2-7807-4e12-b6e8-d5bd463cd7a5" />

---

### ✅ Checklist

- [x] My code follows the project’s guidelines and style.
- [x] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [x] I have tested the changes and confirmed they work as expected.
- [x] My PR is linked to a GitHub issue.

---

### 🙌 Additional Notes
Now, the Privacy Policy is perfect as the whole page is having the same/perfect  UI.