### PR TITLE
Terms First section light/dark mode implemented

### DIFF
--- a/terms-of-service.html
+++ b/terms-of-service.html
@@ -295,6 +295,41 @@
           width: 78px;
         }
       }
+
+      .terms-hero{
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        text-align: center;
+      }
+
+      .terms-hero{
+        background: #ffffff;
+      }
+
+      .terms-hero .hero-title {
+        font-size: 2.5rem;
+        font-weight: 800;
+        margin-bottom: 15px;
+        color: #2c5aa0 !important;
+        text-shadow: none;
+      }
+
+      .terms-hero .hero-subtitle{
+        font-size: 1.2rem;
+        color: #4a5568 !important;
+        opacity: 1;
+        text-shadow: none;
+      }
+
+      .dark-mode .terms-hero{
+        background: #2d3748;
+      }
+
+      .dark-mode .terms-hero .hero-subtitle {
+        color: #ffffff !important;
+      }
     </style>
   </head>
 
@@ -333,9 +368,9 @@
       <div class="terms-hero">
         <div class="hero-content">
           <h1 class="hero-title">Terms of Service</h1>
-          <p class="hero-subtitle">
+          <p class="hero-subtitle"><b>
             Please read these terms carefully before using our research paper
-            organization service.
+            organization service.</b>
           </p>
         </div>
       </div>


### PR DESCRIPTION
## 🚀 Pull Request

### 🔖 Description
Earlier, On the Terms of services page, on the first section, it was fully aligned towards the left as well as the section was not having any effect of the light/dark toggle. But, now the section has been centered, well as well as the light/dark toggle is working for the that section too, in which the background color and the text color respectively to the light/dark option.

Fixes: #879 

---

### 📸 Screenshots (if applicable)
In Light Mode:-
<img width="1366" height="683" alt="use 1" src="https://github.com/user-attachments/assets/df83760b-c30a-42d0-943a-cf51689fa85a" />

In Dark Mode:-
<img width="1366" height="683" alt="use 2" src="https://github.com/user-attachments/assets/6f1531ac-7879-4d75-af7f-2fa253a19f72" />


---

### ✅ Checklist

- [x] My code follows the project’s guidelines and style.
- [x] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [x] I have tested the changes and confirmed they work as expected.
- [x] My PR is linked to a GitHub issue.

---

### 🙌 Additional Notes
Earlier, as this is the first section on the page it was ruining the UI and was also putting bad impression on user, but, now it is perfectly aligned to the UI of the page and is enhancing the user experience.
