### PR TITLE
Contact us on Terms Page Updated

### DIFF
--- a/terms-of-service.html
+++ b/terms-of-service.html
@@ -330,6 +330,32 @@
       .dark-mode .terms-hero .hero-subtitle {
         color: #ffffff !important;
       }
+
+      .contact-info{
+        background: #ffffff;
+        color: #000000;;
+      }
+
+      .contact-info h3 {
+        color: #2c5aa0 !important;
+      }
+
+      .contact-info p,
+      .contact-info a {
+        color: #000000 !important;
+      }
+      .dark-mode .contact-info{
+        background: #2d3748 ;
+      }
+      .dark-mode .contact-info h3 {
+        color: #90cdf4 !important;
+      }
+
+      .dark-mode .contact-info p,
+      .dark-mode .contact-info a {
+        color: #cbd5e1 !important;
+      }
+
     </style>
   </head>
 


### PR DESCRIPTION
## 🚀 Pull Request

### 🔖 Description
Earlier, the contact us section on the Terms of Service  page was not responding to the light/dark toggle button, due to which the color of the background as well as the text was not changing which was breaking the UI of the page. But, now the contact us section changes the background color as well as the text color when the light/dark toggle button is used, it is now enhancing the page UI as it blends with other page.

Fixes: #881 

---

### 📸 Screenshots (if applicable)
In Light Mode:- 
<img width="1364" height="681" alt="image" src="https://github.com/user-attachments/assets/8ac12d95-35b6-4e0c-b242-29ce7ef2fb76" />

In Dark Mode:-
<img width="1363" height="684" alt="image" src="https://github.com/user-attachments/assets/f785331e-c164-465d-82a1-b30e25b11f2b" />

---

### ✅ Checklist

- [ ] My code follows the project’s guidelines and style.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] I have tested the changes and confirmed they work as expected.
- [ ] My PR is linked to a GitHub issue.

---

### 🙌 Additional Notes
Now, the Privacy Policy is perfect as the whole page is having the same/perfect UI.


