### PR TITLE
New Tool Added on Tools Page

### DIFF
--- a/tools.html
+++ b/tools.html
@@ -295,6 +295,18 @@
        <small class="favorite-text">Favorite</small>
    </div>
   </div>
+
+  <div class="tool-card" data-category="papers">
+    <img src="images/research.png" alt="Zotero">
+    <h3>Zotero</h3>
+    <p>Zotero is a tool that helps you collect, organize, cite, and share research. It supports managing bibliographic data and related research materials, such as PDFs</p>
+    <a href="https://www.zotero.org/" target="_blank">Visit</a>
+    <div class="favorite-action">
+       <i class="fa-regular fa-star bookmark-icon" data-tool-id="acm-digital-library" data-tool-name="ACM Digital Library" data-tool-url="https://dl.acm.org/"></i>
+       <small class="favorite-text">Favorite</small>
+   </div>
+  </div>
+  
 </div>
 
     <!-- Back to Top Button -->


### PR DESCRIPTION
## 🚀 Pull Request

### 🔖 Description
On the tools page, at the bottom there was a empty space but now a new tool has been added by the named "Zotero" which is an tool that helps you collect, organize, cite, and share research. 

Fixes: #886 

---

### 📸 Screenshots (if applicable)
<img width="1887" height="957" alt="image" src="https://github.com/user-attachments/assets/c6301255-d258-4ea9-b15e-fe31b3356720" />

<img width="1838" height="877" alt="image" src="https://github.com/user-attachments/assets/822bb680-c083-4576-afb9-475e2fb4dda7" />

---

### ✅ Checklist

- [x] My code follows the project’s guidelines and style.
- [x] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [x] I have tested the changes and confirmed they work as expected.
- [x] My PR is linked to a GitHub issue.

---

### 🙌 Additional Notes
Now, the user can explore one more tool which will help them in their research
