### PR TITLE
Adjust chatbot button position to 20px from bottom 

### DIFF
--- a/index.html
+++ b/index.html
@@ -1857,7 +1857,7 @@ marquee.addEventListener("mouseleave", () => {
       /* Chatbot bubble button anchored bottom-right, above #backToTop */
       button#chatbase-bubble-button {
         position: fixed !important;
-        bottom: 80px !important; /* keep above the back-to-top button */
+        bottom: 20px !important; /* keep above the back-to-top button */
         right: 20px !important;
         width: 55px !important;
         height: 55px !important;


### PR DESCRIPTION
## 🚀 Pull Request

### 🔖 Description
since the chatbot's bubble was not visible when chatbot screen was opened on the main page which was making it hard to close the chatbot. i fixed its size so that it can be visible and now it can be closed easily.
Fixes: # 885

---

### 📸 Screenshots (if applicable)
<img width="1231" height="785" alt="Screenshot 2025-11-27 at 12 56 55 AM" src="https://github.com/user-attachments/assets/2a8061a3-6a2f-4fb7-a124-67c9a61c6f78" />

---
### ✅ Checklist

- [✅] My code follows the project’s guidelines and style.
- [✅] I have commented my code where necessary.
- [✅] I have updated the documentation if needed.
- [✅] I have tested the changes and confirmed they work as expected.
- [✅] My PR is linked to a GitHub issue.

---

### 🙌 Additional Notes
Learning a lot from this PR. Looking forward to work on this project.
