### PR TITLE
Fix user having to explicitly sign in after creating account. Implemented auto sign in after creating account

### DIFF
--- a/js/auth.js
+++ b/js/auth.js
@@ -203,10 +203,16 @@ class AuthSystem {
 
     this.users.push(newUser);
     this.saveUsers();
-
+    // AFTER — add setCurrentUser() before the redirect:
     setTimeout(() => {
+      this.setCurrentUser({        // ✅ ADD THIS
+      id: newUser.id,            // ✅
+      name: newUser.name,        // ✅
+      email: newUser.email,      // ✅
+      rememberMe: false,         // ✅
+      });                          // ✅
       this.showSuccess("Account created successfully!", () => {
-        window.location.href = "index.html";
+      window.location.href = "index.html";
       });
     }, 1500);
   }


### PR DESCRIPTION
## 🚀 Pull Request

### 🔖 Description
After a user successfully creates an account, they were being redirected to index.html but were not signed in — treated as a guest and forced to log in manually a second time.
The root cause was in js/auth.js: handleSignup() saved the new user to USERS_KEY but never called setCurrentUser(), so no session was established. The fix adds a setCurrentUser() call inside the setTimeout in handleSignup(), using the already-constructed newUser object — matching the exact pattern used in handleLogin().
Fixes: # (paste your issue number here)

Fixes: #900 

---

### 📸 Screenshots (if applicable)
NA

---

### ✅ Checklist

- [x] My code follows the project’s guidelines and style.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] I have tested the changes and confirmed they work as expected.
- [x] My PR is linked to a GitHub issue.

---

### 🙌 Additional Notes
The fix is a single setCurrentUser() call — 5 lines added to handleSignup() in js/auth.js. No new logic was introduced; it reuses the existing method that handleLogin() already relies on. Tested locally by creating a new account and confirming localStorage.getItem('current_user') is populated on redirect.